### PR TITLE
Feature/2 댓글 기능 DTO 및 기본 구조 설계

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -33,6 +33,10 @@ dependencies {
 	annotationProcessor("org.projectlombok:lombok")
 	testImplementation("org.springframework.boot:spring-boot-starter-test")
 	testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+	implementation ("io.github.openfeign.querydsl:querydsl-jpa:6.10.1")
+	annotationProcessor ("io.github.openfeign.querydsl:querydsl-apt:6.10.1:jpa")
+	annotationProcessor ("jakarta.annotation:jakarta.annotation-api")
+	annotationProcessor ("jakarta.persistence:jakarta.persistence-api")
 }
 
 tasks.withType<Test> {

--- a/src/main/java/com/algangi/mongle/comment/domain/Comment.java
+++ b/src/main/java/com/algangi/mongle/comment/domain/Comment.java
@@ -1,4 +1,4 @@
-package com.algangi.mongle.comment;
+package com.algangi.mongle.comment.domain;
 
 import com.algangi.mongle.global.entity.TimeBaseEntity;
 import com.algangi.mongle.member.domain.Member;

--- a/src/main/java/com/algangi/mongle/comment/domain/Comment.java
+++ b/src/main/java/com/algangi/mongle/comment/domain/Comment.java
@@ -18,6 +18,9 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SoftDelete;
+
+import java.time.LocalDateTime;
 
 @Entity
 @Table(name = "comment")
@@ -25,6 +28,7 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @Builder
 @Getter
+@SoftDelete
 public class Comment extends TimeBaseEntity {
 
     @Id
@@ -53,6 +57,8 @@ public class Comment extends TimeBaseEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id")
     private Member member;
+
+    private LocalDateTime deletedAt;
 
     public static Comment createParentComment(String content, Post post, Member member) {
         Comment comment = Comment.builder()
@@ -91,4 +97,5 @@ public class Comment extends TimeBaseEntity {
         return parentComment != null;
     }
 
+    public boolean isDeleted() { return deletedAt != null; }
 }

--- a/src/main/java/com/algangi/mongle/comment/domain/CommentSort.java
+++ b/src/main/java/com/algangi/mongle/comment/domain/CommentSort.java
@@ -1,0 +1,5 @@
+package com.algangi.mongle.comment.domain;
+
+public enum CommentSort {
+    LATEST, LIKES
+}

--- a/src/main/java/com/algangi/mongle/comment/dto/CommentCreateRequest.java
+++ b/src/main/java/com/algangi/mongle/comment/dto/CommentCreateRequest.java
@@ -1,0 +1,12 @@
+package com.algangi.mongle.comment.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public record CommentCreateRequest (
+        @NotBlank(message = "댓글 내용은 비워둘 수 없습니다.")
+        @Size(max = 1000, message = "댓글은 최대 1000자까지 작성 가능합니다.")
+        String content
+){
+
+}

--- a/src/main/java/com/algangi/mongle/comment/dto/CommentInfoResponse.java
+++ b/src/main/java/com/algangi/mongle/comment/dto/CommentInfoResponse.java
@@ -1,0 +1,53 @@
+package com.algangi.mongle.comment.dto;
+
+import com.algangi.mongle.comment.domain.Comment;
+import java.time.LocalDateTime;
+import java.util.Collections;
+import java.util.List;
+
+public record CommentInfoResponse(
+        Long commentId,
+        String content,
+        String authorNickname,
+        String authorProfileImageUrl,
+        long likeCount,
+        long dislikeCount,
+        LocalDateTime createdAt,
+        boolean isAuthor,
+        boolean isDeleted,
+        List<CommentInfoResponse> replies
+) {
+
+    private static final String MASKED_CONTENT = "삭제된 댓글입니다.";
+    private static final String MASKED_NICKNAME = "(알 수 없음)";
+    private static final String DEFAULT_PROFILE_IMAGE_URL = "default_profile_image_url";
+
+    public static CommentInfoResponse fromParent(Comment parentComment, Long currentMemberId, List<CommentInfoResponse> replies) {
+        List<CommentInfoResponse> safeReplies = (replies != null) ? List.copyOf(replies) : List.of();
+        return createResponse(parentComment, currentMemberId, safeReplies);
+    }
+
+    public static CommentInfoResponse fromChild(Comment childComment, Long currentMemberId) {
+        return createResponse(childComment, currentMemberId, Collections.emptyList());
+    }
+
+    private static CommentInfoResponse createResponse(Comment comment, Long currentMemberId, List<CommentInfoResponse> replies) {
+        boolean isDeleted = comment.isDeleted();
+        boolean isAuthor = !isDeleted &&
+                currentMemberId != null &&
+                currentMemberId.equals(comment.getMember().getMemberId());
+
+        return new CommentInfoResponse(
+                comment.getId(),
+                isDeleted ? MASKED_CONTENT : comment.getContent(),
+                isDeleted ? MASKED_NICKNAME : comment.getMember().getNickname(),
+                isDeleted ? DEFAULT_PROFILE_IMAGE_URL : comment.getMember().getProfileImage(),
+                isDeleted ? 0 : comment.getLikeCount(),
+                isDeleted ? 0 : comment.getDislikeCount(),
+                comment.getCreatedDate(),
+                isAuthor,
+                isDeleted,
+                replies
+        );
+    }
+}

--- a/src/main/java/com/algangi/mongle/comment/dto/CursorInfoResponse.java
+++ b/src/main/java/com/algangi/mongle/comment/dto/CursorInfoResponse.java
@@ -1,0 +1,26 @@
+package com.algangi.mongle.comment.dto;
+
+import java.util.Collections;
+import java.util.List;
+
+public record CursorInfoResponse<T>(
+        List<T> values,
+        String nextCursor,
+        boolean hasNext
+) {
+
+    public CursorInfoResponse(List<T> values, String nextCursor, boolean hasNext) {
+        this.values = List.copyOf(values);
+        this.nextCursor = nextCursor;
+        this.hasNext = hasNext;
+    }
+
+    public static <T> CursorInfoResponse<T> of(List<T> values, String nextCursor) {
+        boolean hasNext = nextCursor != null && !nextCursor.isBlank();
+        return new CursorInfoResponse<>(values, nextCursor, hasNext);
+    }
+
+    public static <T> CursorInfoResponse<T> empty() {
+        return new CursorInfoResponse<>(Collections.emptyList(), null, false);
+    }
+}

--- a/src/main/java/com/algangi/mongle/comment/exception/CommentErrorCode.java
+++ b/src/main/java/com/algangi/mongle/comment/exception/CommentErrorCode.java
@@ -1,0 +1,19 @@
+package com.algangi.mongle.comment.exception;
+
+import com.algangi.mongle.global.exception.ErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum CommentErrorCode implements ErrorCode {
+
+    REPLY_TO_REPLY_NOT_ALLOWED(HttpStatus.BAD_REQUEST, "COMMENT-001", "대댓글에는 답글을 작성할 수 없습니다."),
+    COMMENT_ACCESS_DENIED(HttpStatus.FORBIDDEN, "COMMENT-002", "댓글에 대한 권한이 없습니다."),
+    COMMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "COMMENT-003", "댓글을 찾을 수 없습니다.");
+
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/com/algangi/mongle/comment/repository/CommentJpaRepository.java
+++ b/src/main/java/com/algangi/mongle/comment/repository/CommentJpaRepository.java
@@ -1,0 +1,8 @@
+package com.algangi.mongle.comment.repository;
+
+import com.algangi.mongle.comment.domain.Comment;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CommentJpaRepository extends JpaRepository<Comment, Long> {
+
+}

--- a/src/main/java/com/algangi/mongle/comment/service/CommentFinder.java
+++ b/src/main/java/com/algangi/mongle/comment/service/CommentFinder.java
@@ -1,0 +1,24 @@
+package com.algangi.mongle.comment.service;
+
+import com.algangi.mongle.comment.domain.Comment;
+import com.algangi.mongle.comment.exception.CommentErrorCode;
+import com.algangi.mongle.comment.repository.CommentJpaRepository;
+import com.algangi.mongle.global.exception.ApplicationException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true, propagation = Propagation.SUPPORTS)
+public class CommentFinder {
+
+    private final CommentJpaRepository commentJpaRepository;
+
+    public Comment getCommentOrThrow(Long commentId) {
+        return commentJpaRepository.findById(commentId)
+                .orElseThrow(() -> new ApplicationException(CommentErrorCode.COMMENT_NOT_FOUND));
+    }
+
+}

--- a/src/main/java/com/algangi/mongle/global/config/QueryDslConfig.java
+++ b/src/main/java/com/algangi/mongle/global/config/QueryDslConfig.java
@@ -1,0 +1,19 @@
+package com.algangi.mongle.global.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class QueryDslConfig {
+
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory() {
+        return new JPAQueryFactory(entityManager);
+    }
+}

--- a/src/main/java/com/algangi/mongle/member/domain/Member.java
+++ b/src/main/java/com/algangi/mongle/member/domain/Member.java
@@ -11,16 +11,14 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 @Entity
 @Table(name = "member")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @Builder
+@Getter
 public class Member extends TimeBaseEntity {
 
     @Id

--- a/src/main/java/com/algangi/mongle/member/exception/MemberErrorCode.java
+++ b/src/main/java/com/algangi/mongle/member/exception/MemberErrorCode.java
@@ -1,0 +1,17 @@
+package com.algangi.mongle.member.exception;
+
+import com.algangi.mongle.global.exception.ErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum MemberErrorCode implements ErrorCode {
+
+    MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "MEMBER-001", "회원을 찾을 수 없습니다.");
+
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/com/algangi/mongle/member/repository/MemberJpaRepository.java
+++ b/src/main/java/com/algangi/mongle/member/repository/MemberJpaRepository.java
@@ -1,0 +1,8 @@
+package com.algangi.mongle.member.repository;
+
+import com.algangi.mongle.member.domain.Member;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MemberJpaRepository extends JpaRepository<Member, Long>{
+
+}

--- a/src/main/java/com/algangi/mongle/member/service/MemberFinder.java
+++ b/src/main/java/com/algangi/mongle/member/service/MemberFinder.java
@@ -1,0 +1,26 @@
+package com.algangi.mongle.member.service;
+
+import com.algangi.mongle.member.domain.Member;
+import com.algangi.mongle.member.exception.MemberErrorCode;
+import com.algangi.mongle.member.repository.MemberJpaRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.algangi.mongle.global.exception.ApplicationException;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true, propagation = Propagation.SUPPORTS)
+public class MemberFinder {
+
+    private final MemberJpaRepository memberJpaRepository;
+
+    public Member getMemberOrThrow(Long memberId) {
+        return memberJpaRepository.findById(memberId)
+                .orElseThrow(() -> new ApplicationException(MemberErrorCode.MEMBER_NOT_FOUND));
+    }
+
+}

--- a/src/main/java/com/algangi/mongle/post/domain/Post.java
+++ b/src/main/java/com/algangi/mongle/post/domain/Post.java
@@ -3,7 +3,7 @@ package com.algangi.mongle.post.domain;
 import java.util.ArrayList;
 import java.util.List;
 
-import com.algangi.mongle.comment.Comment;
+import com.algangi.mongle.comment.domain.Comment;
 import com.algangi.mongle.dynamicCloud.domain.DynamicCloud;
 import com.algangi.mongle.global.entity.TimeBaseEntity;
 


### PR DESCRIPTION
## 📄Summary
- 댓글/대댓글 등록, 조회, 삭제 API에서 사용할 DTO 정의
- CommentFinder MemberFinder Finder 클래스 추가
- 도메인별 예외 및 ErrorCode Enum 설계
- OpenFeign QueryDSL 환경 설정

<br><br>

## 🙋🏻 More
- 댓글 길이를 임의로 1,000자로 제한해 두었습니다.
- 삭제된 댓글이 조회될 때는 다음과 같이 필드가 마스킹 처리되어 반환됩니다.
  - content: 삭제된 댓글입니다.
  - authorNickname: (알 수 없음)
  - authorProfileImageUrl : default_profile_image_url
  - likeCount, dislikeCount: 0으로 반환

<br><br>

## 🔗관련 이슈
- Close #2 
