### PR TITLE
Feat/4 댓글 및 대댓글 등록 API 구현

### DIFF
--- a/src/main/java/com/algangi/mongle/comment/controller/CommentController.java
+++ b/src/main/java/com/algangi/mongle/comment/controller/CommentController.java
@@ -1,0 +1,31 @@
+package com.algangi.mongle.comment.controller;
+
+import com.algangi.mongle.comment.dto.CommentCreateRequest;
+import com.algangi.mongle.comment.service.CommentService;
+import com.algangi.mongle.global.dto.ApiResponse;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1")
+@RequiredArgsConstructor
+public class CommentController {
+
+    private final CommentService commentService;
+
+    @PostMapping("/posts/{postId}/comments")
+    public ResponseEntity<ApiResponse<Void>> createParentComment(@PathVariable(name = "postId") Long postId,
+                                                                 @Valid @RequestBody CommentCreateRequest dto,
+                                                                 @RequestParam Long memberId) {
+        commentService.createParentComment(postId, dto, memberId);
+        return ResponseEntity.ok(ApiResponse.success());
+    }
+
+}

--- a/src/main/java/com/algangi/mongle/comment/controller/CommentController.java
+++ b/src/main/java/com/algangi/mongle/comment/controller/CommentController.java
@@ -28,4 +28,12 @@ public class CommentController {
         return ResponseEntity.ok(ApiResponse.success());
     }
 
+    @PostMapping("/comments/{parentCommentId}/replies")
+    public ResponseEntity<ApiResponse<Void>> createChildComment(@PathVariable(name = "parentCommentId") Long parentCommentId,
+                                                                @Valid @RequestBody CommentCreateRequest dto,
+                                                                @RequestParam Long memberId) {
+        commentService.createChildComment(parentCommentId, dto, memberId);
+        return ResponseEntity.ok(ApiResponse.success());
+    }
+
 }

--- a/src/main/java/com/algangi/mongle/comment/domain/Comment.java
+++ b/src/main/java/com/algangi/mongle/comment/domain/Comment.java
@@ -46,7 +46,7 @@ public class Comment extends TimeBaseEntity {
     @Builder.Default
     private long dislikeCount = 0;
 
-    @ManyToOne(fetch = FetchType.LAZY)
+    @ManyToOne(fetch = FetchType.EAGER)
     @JoinColumn(name = "parent_comment_id")
     private Comment parentComment;
 

--- a/src/main/java/com/algangi/mongle/comment/service/CommentService.java
+++ b/src/main/java/com/algangi/mongle/comment/service/CommentService.java
@@ -30,4 +30,16 @@ public class CommentService {
         );
     }
 
+    @Transactional
+    public void createChildComment(Long parentCommentId, CommentCreateRequest dto, Long memberId) {
+        Member author = memberFinder.getMemberOrThrow(memberId);
+        Comment comment = commentFinder.getCommentOrThrow(parentCommentId);
+
+        Comment.createChildComment(
+                dto.content(),
+                comment,
+                author
+        );
+    }
+
 }

--- a/src/main/java/com/algangi/mongle/comment/service/CommentService.java
+++ b/src/main/java/com/algangi/mongle/comment/service/CommentService.java
@@ -1,0 +1,33 @@
+package com.algangi.mongle.comment.service;
+
+import com.algangi.mongle.comment.domain.Comment;
+import com.algangi.mongle.comment.dto.CommentCreateRequest;
+import com.algangi.mongle.member.domain.Member;
+import com.algangi.mongle.member.service.MemberFinder;
+import com.algangi.mongle.post.domain.Post;
+import com.algangi.mongle.post.service.PostFinder;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class CommentService {
+
+    private final MemberFinder memberFinder;
+    private final PostFinder postFinder;
+    private final CommentFinder commentFinder;
+
+    @Transactional
+    public void createParentComment(Long postId, CommentCreateRequest dto, Long memberId) {
+        Member author = memberFinder.getMemberOrThrow(memberId);
+        Post post = postFinder.getPostOrThrow(postId);
+
+        Comment.createParentComment(
+                dto.content(),
+                post,
+                author
+        );
+    }
+
+}


### PR DESCRIPTION
## 📄Summary
- 부모 댓글 등록 기능 구현(게시물-댓글)
- 대댓글 등록 기능 구현

<br><br>

## 🙋🏻 More
Hibernate 6+에서 @SoftDelete가 붙은 parentComment를 LAZY로 매핑할 수 없는 문제를 해결하기 위해 parentComment를 EAGER로 변경했습니다. 현재 댓글의 depth가 제한되어 있고, 댓글을 한 번에 모두 조회하지 않고 페이징을 사용해 일부만 조회할 예정이라 한 번에 로딩되는 parentComment 수가 제한되어 부하가 크진 않을 것으로 예상됩니다. 추후 필요하다면 softdelete 기능을 직접 구현하는 방안을 고려해보겠습니다.

<br><br>

## 🔗관련 이슈
- Close #이슈번호
