### PR TITLE
Feat/5 게시글 상세 조회, 게시글 목록 조회, 화면 지도 내 객체 조회

### DIFF
--- a/src/main/java/com/algangi/mongle/comment/domain/repository/CommentQueryRepository.java
+++ b/src/main/java/com/algangi/mongle/comment/domain/repository/CommentQueryRepository.java
@@ -9,7 +9,14 @@ import java.util.List;
 import java.util.Map;
 
 public interface CommentQueryRepository {
+
     PaginationResult<Comment> findCommentsByPost(CommentSearchCondition condition, int size);
+
     PaginationResult<Comment> findRepliesByParent(ReplySearchCondition condition, int size);
+
     Map<Long, Boolean> findHasRepliesByParentIds(List<Long> parentIds);
+
+    long countByPostId(String postId);
+
+    Map<String, Long> countCommentsByPostIds(List<String> postIds);
 }

--- a/src/main/java/com/algangi/mongle/comment/infrastructure/persistence/CommentQueryDslRepository.java
+++ b/src/main/java/com/algangi/mongle/comment/infrastructure/persistence/CommentQueryDslRepository.java
@@ -99,7 +99,7 @@ public class CommentQueryDslRepository implements CommentQueryRepository {
         Long count = queryFactory
             .select(comment.count())
             .from(comment)
-            .where(comment.post.id.eq(postId))
+            .where(comment.post.id.eq(postId), comment.deletedAt.isNull())
             .fetchOne();
         return count != null ? count : 0L;
     }
@@ -111,7 +111,7 @@ public class CommentQueryDslRepository implements CommentQueryRepository {
         }
         return queryFactory
             .from(comment)
-            .where(comment.post.id.in(postIds))
+            .where(comment.post.id.in(postIds), comment.deletedAt.isNull())
             .groupBy(comment.post.id)
             .transform(GroupBy.groupBy(comment.post.id).as(comment.count()));
     }

--- a/src/main/java/com/algangi/mongle/comment/infrastructure/persistence/CommentQueryDslRepository.java
+++ b/src/main/java/com/algangi/mongle/comment/infrastructure/persistence/CommentQueryDslRepository.java
@@ -56,6 +56,7 @@ public class CommentQueryDslRepository implements CommentQueryRepository {
             .leftJoin(comment.member).fetchJoin()
             .where(
                 filterFactory.eqParentId(condition.parentId()),
+                comment.deletedAt.isNull(),
                 filterFactory.cursorCondition(condition.cursor(), condition.sort())
             )
             .orderBy(orderFactory.createOrderSpecifiers(condition.sort()))

--- a/src/main/java/com/algangi/mongle/dynamicCloud/domain/repository/DynamicCloudRepository.java
+++ b/src/main/java/com/algangi/mongle/dynamicCloud/domain/repository/DynamicCloudRepository.java
@@ -1,14 +1,12 @@
 package com.algangi.mongle.dynamicCloud.domain.repository;
 
-import java.util.List;
-import java.util.Optional;
-import java.util.Set;
-
+import com.algangi.mongle.dynamicCloud.domain.model.DynamicCloud;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
-import com.algangi.mongle.dynamicCloud.domain.model.DynamicCloud;
+import java.util.List;
+import java.util.Optional;
 
 public interface DynamicCloudRepository extends JpaRepository<DynamicCloud, Long> {
 
@@ -16,8 +14,14 @@ public interface DynamicCloudRepository extends JpaRepository<DynamicCloud, Long
         "where s2TokenId = :s2TokenId and dc.status = 'ACTIVE'")
     Optional<DynamicCloud> findActiveByS2TokenId(@Param("s2TokenId") String s2TokenId);
 
+    /**
+     * 주어진 S2 Cell 목록과 겹치는 활성 상태의 동적 구름을 모두 조회합니다.
+     *
+     * @param s2TokenIds S2 Cell 토큰 ID 목록
+     * @return 활성 상태의 동적 구름(DynamicCloud) 목록
+     */
     @Query("select DISTINCT dc from DynamicCloud dc join dc.s2TokenIds s2TokenId " +
         "where s2TokenId in :s2TokenIds and dc.status = 'ACTIVE'")
-    List<DynamicCloud> findActiveCloudsInCells(@Param("s2TokenIds") Set<String> s2TokenIds);
+    List<DynamicCloud> findActiveCloudsInCells(@Param("s2TokenIds") List<String> s2TokenIds);
 
 }

--- a/src/main/java/com/algangi/mongle/dynamicCloud/domain/repository/DynamicCloudRepository.java
+++ b/src/main/java/com/algangi/mongle/dynamicCloud/domain/repository/DynamicCloudRepository.java
@@ -7,6 +7,7 @@ import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 
 public interface DynamicCloudRepository extends JpaRepository<DynamicCloud, Long> {
 
@@ -14,14 +15,10 @@ public interface DynamicCloudRepository extends JpaRepository<DynamicCloud, Long
         "where s2TokenId = :s2TokenId and dc.status = 'ACTIVE'")
     Optional<DynamicCloud> findActiveByS2TokenId(@Param("s2TokenId") String s2TokenId);
 
-    /**
-     * 주어진 S2 Cell 목록과 겹치는 활성 상태의 동적 구름을 모두 조회합니다.
-     *
-     * @param s2TokenIds S2 Cell 토큰 ID 목록
-     * @return 활성 상태의 동적 구름(DynamicCloud) 목록
-     */
+    // 주어진 S2 Cell 목록과 겹치는 활성화된 동적 구름들을 조회
     @Query("select DISTINCT dc from DynamicCloud dc join dc.s2TokenIds s2TokenId " +
-        "where s2TokenId in :s2TokenIds and dc.status = 'ACTIVE'")
-    List<DynamicCloud> findActiveCloudsInCells(@Param("s2TokenIds") List<String> s2TokenIds);
+        "where s2TokenId in :s2cellTokens and dc.status = 'ACTIVE'")
+    List<DynamicCloud> findActiveCloudsInCells(@Param("s2cellTokens") List<String> s2cellTokens);
 
 }
+

--- a/src/main/java/com/algangi/mongle/dynamicCloud/domain/service/DynamicCloudFormationService.java
+++ b/src/main/java/com/algangi/mongle/dynamicCloud/domain/service/DynamicCloudFormationService.java
@@ -1,19 +1,17 @@
 package com.algangi.mongle.dynamicCloud.domain.service;
 
-import java.util.ArrayList;
-import java.util.Comparator;
-import java.util.List;
-import java.util.Set;
-
-import org.springframework.stereotype.Service;
-
 import com.algangi.mongle.dynamicCloud.domain.model.DynamicCloud;
 import com.algangi.mongle.dynamicCloud.domain.repository.DynamicCloudRepository;
 import com.algangi.mongle.global.domain.service.CellService;
 import com.algangi.mongle.post.domain.model.Post;
 import com.algangi.mongle.post.domain.repository.PostRepository;
-
 import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Set;
 
 @Service
 @RequiredArgsConstructor
@@ -30,8 +28,9 @@ public class DynamicCloudFormationService {
 
         // 2. 인접 동적 구름 조회
         Set<String> adjacentS2TokenIds = cellService.getAdjacentCells(s2TokenId);
+        // Set을 List로 변환하여 메서드 호출
         List<DynamicCloud> adjacentClouds = dynamicCloudRepository.findActiveCloudsInCells(
-            adjacentS2TokenIds);
+            new ArrayList<>(adjacentS2TokenIds));
 
         DynamicCloud finalCloud = newDynamicCloud;
         if (!adjacentClouds.isEmpty()) {
@@ -81,3 +80,4 @@ public class DynamicCloudFormationService {
         return oldestCloud;
     }
 }
+

--- a/src/main/java/com/algangi/mongle/global/infrastructure/S2CellService.java
+++ b/src/main/java/com/algangi/mongle/global/infrastructure/S2CellService.java
@@ -1,14 +1,13 @@
 package com.algangi.mongle.global.infrastructure;
 
-import java.util.ArrayList;
-import java.util.Set;
-import java.util.stream.Collectors;
-
+import com.algangi.mongle.global.domain.service.CellService;
+import com.google.common.geometry.*;
 import org.springframework.stereotype.Service;
 
-import com.algangi.mongle.global.domain.service.CellService;
-import com.google.common.geometry.S2CellId;
-import com.google.common.geometry.S2LatLng;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 @Service
 public class S2CellService implements CellService {
@@ -34,4 +33,23 @@ public class S2CellService implements CellService {
             .map(S2CellId::toToken)
             .collect(Collectors.toSet());
     }
+
+    public List<String> getCellsForRect(double swLat, double swLng, double neLat, double neLng) {
+        S2LatLngRect rect = S2LatLngRect.fromPointPair(
+            S2LatLng.fromDegrees(swLat, swLng),
+            S2LatLng.fromDegrees(neLat, neLng)
+        );
+
+        S2RegionCoverer coverer = new S2RegionCoverer();
+        coverer.setMinLevel(S2_CELL_LEVEL);
+        coverer.setMaxLevel(S2_CELL_LEVEL);
+
+        ArrayList<S2CellId> covering = new ArrayList<>();
+        coverer.getCovering(rect, covering);
+
+        return covering.stream()
+            .map(S2CellId::toToken)
+            .collect(Collectors.toList());
+    }
 }
+

--- a/src/main/java/com/algangi/mongle/global/util/S2PolygonConverter.java
+++ b/src/main/java/com/algangi/mongle/global/util/S2PolygonConverter.java
@@ -4,10 +4,10 @@ import com.algangi.mongle.map.presentation.dto.MapObjectsResponse;
 import com.google.common.geometry.S2Cell;
 import com.google.common.geometry.S2CellId;
 import com.google.common.geometry.S2LatLng;
-import com.google.common.geometry.S2Loop;
 import com.google.common.geometry.S2Point;
 import com.google.common.geometry.S2Polygon;
 import com.google.common.geometry.S2PolygonBuilder;
+import com.google.common.geometry.S2Loop;
 import org.springframework.stereotype.Component;
 
 import java.util.ArrayList;
@@ -19,12 +19,13 @@ import java.util.stream.Collectors;
 public class S2PolygonConverter {
 
     /**
-     * S2 토큰 Set을 받아 외부 경계를 나타내는 좌표 List로 변환합니다.
+     * S2 Cell ID 집합으로부터 외부 경계 폴리곤을 생성합니다. 프론트엔드에서 폴리곤을 그릴 수 있도록 마지막 좌표는 첫 좌표와 동일하게 설정됩니다 (Closed
+     * Polygon).
      *
-     * @param s2Tokens S2 Cell ID 토큰 Set
-     * @return 경계 좌표 List
+     * @param s2Tokens S2 Cell 토큰 ID 집합
+     * @return 폴리곤의 꼭짓점 좌표 리스트
      */
-    public List<MapObjectsResponse.Coordinate> convertS2TokensToPolygon(Set<String> s2Tokens) {
+    public List<MapObjectsResponse.Coordinate> convert(Set<String> s2Tokens) {
         if (s2Tokens == null || s2Tokens.isEmpty()) {
             return new ArrayList<>();
         }
@@ -32,29 +33,28 @@ public class S2PolygonConverter {
         S2PolygonBuilder builder = new S2PolygonBuilder(S2PolygonBuilder.Options.DIRECTED_XOR);
         for (String token : s2Tokens) {
             S2CellId cellId = S2CellId.fromToken(token);
-            S2Loop loop = new S2Loop(new S2Cell(cellId));
-            builder.addLoop(loop);
+            builder.addLoop(new S2Loop(new S2Cell(cellId)));
         }
 
         S2Polygon polygon = new S2Polygon();
-        builder.assemblePolygon(polygon, null);
-
-        if (polygon.numLoops() == 0) {
+        if (!builder.assemblePolygon(polygon, null) || polygon.numLoops() == 0) {
             return new ArrayList<>();
         }
 
         S2Loop outerLoop = polygon.loop(0);
-        List<S2Point> vertices = new ArrayList<>();
+        List<MapObjectsResponse.Coordinate> coordinates = new ArrayList<>();
         for (int i = 0; i < outerLoop.numVertices(); i++) {
-            vertices.add(outerLoop.vertex(i));
+            S2Point vertex = outerLoop.vertex(i);
+            S2LatLng latLng = new S2LatLng(vertex);
+            coordinates.add(
+                new MapObjectsResponse.Coordinate(latLng.latDegrees(), latLng.lngDegrees()));
         }
 
-        return vertices.stream()
-            .map(s2Point -> {
-                S2LatLng latLng = new S2LatLng(s2Point);
-                return new MapObjectsResponse.Coordinate(latLng.latDegrees(), latLng.lngDegrees());
-            })
-            .collect(Collectors.toList());
+        if (!coordinates.isEmpty()) {
+            coordinates.add(coordinates.getFirst());
+        }
+
+        return coordinates;
     }
 }
 

--- a/src/main/java/com/algangi/mongle/global/util/S2PolygonConverter.java
+++ b/src/main/java/com/algangi/mongle/global/util/S2PolygonConverter.java
@@ -1,0 +1,60 @@
+package com.algangi.mongle.global.util;
+
+import com.algangi.mongle.map.presentation.dto.MapObjectsResponse;
+import com.google.common.geometry.S2Cell;
+import com.google.common.geometry.S2CellId;
+import com.google.common.geometry.S2LatLng;
+import com.google.common.geometry.S2Loop;
+import com.google.common.geometry.S2Point;
+import com.google.common.geometry.S2Polygon;
+import com.google.common.geometry.S2PolygonBuilder;
+import org.springframework.stereotype.Component;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+@Component
+public class S2PolygonConverter {
+
+    /**
+     * S2 토큰 Set을 받아 외부 경계를 나타내는 좌표 List로 변환합니다.
+     *
+     * @param s2Tokens S2 Cell ID 토큰 Set
+     * @return 경계 좌표 List
+     */
+    public List<MapObjectsResponse.Coordinate> convertS2TokensToPolygon(Set<String> s2Tokens) {
+        if (s2Tokens == null || s2Tokens.isEmpty()) {
+            return new ArrayList<>();
+        }
+
+        S2PolygonBuilder builder = new S2PolygonBuilder(S2PolygonBuilder.Options.DIRECTED_XOR);
+        for (String token : s2Tokens) {
+            S2CellId cellId = S2CellId.fromToken(token);
+            S2Loop loop = new S2Loop(new S2Cell(cellId));
+            builder.addLoop(loop);
+        }
+
+        S2Polygon polygon = new S2Polygon();
+        builder.assemblePolygon(polygon, null);
+
+        if (polygon.numLoops() == 0) {
+            return new ArrayList<>();
+        }
+
+        S2Loop outerLoop = polygon.loop(0);
+        List<S2Point> vertices = new ArrayList<>();
+        for (int i = 0; i < outerLoop.numVertices(); i++) {
+            vertices.add(outerLoop.vertex(i));
+        }
+
+        return vertices.stream()
+            .map(s2Point -> {
+                S2LatLng latLng = new S2LatLng(s2Point);
+                return new MapObjectsResponse.Coordinate(latLng.latDegrees(), latLng.lngDegrees());
+            })
+            .collect(Collectors.toList());
+    }
+}
+

--- a/src/main/java/com/algangi/mongle/map/application/service/MapQueryService.java
+++ b/src/main/java/com/algangi/mongle/map/application/service/MapQueryService.java
@@ -1,0 +1,102 @@
+package com.algangi.mongle.map.application.service;
+
+import com.algangi.mongle.dynamicCloud.domain.model.DynamicCloud;
+import com.algangi.mongle.dynamicCloud.domain.repository.DynamicCloudRepository;
+import com.algangi.mongle.global.infrastructure.S2CellService;
+import com.algangi.mongle.map.presentation.dto.MapObjectsRequest;
+import com.algangi.mongle.map.presentation.dto.MapObjectsResponse;
+import com.algangi.mongle.member.domain.Member;
+import com.algangi.mongle.member.service.MemberFinder;
+import com.algangi.mongle.post.domain.model.Post;
+import com.algangi.mongle.post.domain.repository.PostQueryRepository;
+import com.algangi.mongle.staticCloud.domain.model.StaticCloud;
+import com.algangi.mongle.staticCloud.repository.StaticCloudRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class MapQueryService {
+
+    private final S2CellService s2CellService;
+    private final PostQueryRepository postQueryRepository;
+    private final StaticCloudRepository staticCloudRepository;
+    private final DynamicCloudRepository dynamicCloudRepository;
+    private final MemberFinder memberFinder;
+
+    public MapObjectsResponse getMapObjects(MapObjectsRequest request) {
+        List<String> s2cellTokens = s2CellService.getCellsForRect(
+            request.swLat(), request.swLng(), request.neLat(), request.neLng()
+        );
+
+        if (s2cellTokens.isEmpty()) {
+            return MapObjectsResponse.empty();
+        }
+
+        List<Post> grains = postQueryRepository.findGrainsInCells(s2cellTokens);
+        List<StaticCloud> staticClouds = staticCloudRepository.findCloudsInCells(s2cellTokens);
+        List<DynamicCloud> dynamicClouds = dynamicCloudRepository.findActiveCloudsInCells(
+            s2cellTokens);
+
+        Map<Long, Member> authors = getAuthorsForGrains(grains);
+
+        List<MapObjectsResponse.Grain> grainDtos = grains.stream()
+            .map(post -> {
+                Member author = authors.get(post.getAuthorId());
+                String profileImageUrl = (author != null) ? author.getProfileImage() : null;
+                return new MapObjectsResponse.Grain(
+                    post.getId(),
+                    post.getLocation().getLatitude(),
+                    post.getLocation().getLongitude(),
+                    profileImageUrl
+                );
+            })
+            .toList();
+
+        List<MapObjectsResponse.StaticCloudInfo> staticCloudDtos = staticClouds.stream()
+            .map(cloud -> new MapObjectsResponse.StaticCloudInfo(
+                cloud.getId().toString(),
+                cloud.getName(),
+                cloud.getLatitude(),
+                cloud.getLongitude(),
+                // TODO: 해당 구름의 게시글 수 집계 로직 필요
+                42,
+                // TODO: 구름의 폴리곤 좌표 생성 로직 필요
+                Collections.emptyList()
+            ))
+            .toList();
+
+        List<MapObjectsResponse.DynamicCloudInfo> dynamicCloudDtos = dynamicClouds.stream()
+            .map(cloud -> new MapObjectsResponse.DynamicCloudInfo(
+                cloud.getId().toString(),
+                // TODO: 해당 구름의 게시글 수 집계 로직 필요
+                15,
+                // TODO: 구름의 폴리곤 좌표 생성 로직 필요
+                Collections.emptyList()
+            ))
+            .toList();
+
+        return new MapObjectsResponse(grainDtos, staticCloudDtos, dynamicCloudDtos);
+    }
+
+    private Map<Long, Member> getAuthorsForGrains(List<Post> grains) {
+        if (grains.isEmpty()) {
+            return Collections.emptyMap();
+        }
+        List<Long> authorIds = grains.stream()
+            .map(Post::getAuthorId)
+            .distinct()
+            .toList();
+        return memberFinder.findMembersByIds(authorIds).stream()
+            .collect(Collectors.toMap(Member::getMemberId, Function.identity()));
+    }
+}
+

--- a/src/main/java/com/algangi/mongle/map/presentation/controller/MapController.java
+++ b/src/main/java/com/algangi/mongle/map/presentation/controller/MapController.java
@@ -1,0 +1,29 @@
+package com.algangi.mongle.map.presentation.controller;
+
+import com.algangi.mongle.global.dto.ApiResponse;
+import com.algangi.mongle.map.application.service.MapQueryService;
+import com.algangi.mongle.map.presentation.dto.MapObjectsRequest;
+import com.algangi.mongle.map.presentation.dto.MapObjectsResponse;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/map")
+@RequiredArgsConstructor
+public class MapController {
+
+    private final MapQueryService mapQueryService;
+
+    @GetMapping("/objects")
+    public ResponseEntity<ApiResponse<MapObjectsResponse>> getMapObjects(
+        @Valid @ModelAttribute MapObjectsRequest request) {
+
+        MapObjectsResponse response = mapQueryService.getMapObjects(request);
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+}

--- a/src/main/java/com/algangi/mongle/map/presentation/dto/MapObjectsRequest.java
+++ b/src/main/java/com/algangi/mongle/map/presentation/dto/MapObjectsRequest.java
@@ -1,0 +1,12 @@
+package com.algangi.mongle.map.presentation.dto;
+
+import jakarta.validation.constraints.NotNull;
+
+public record MapObjectsRequest(
+    @NotNull(message = "swLat은 필수값입니다.") Double swLat,
+    @NotNull(message = "swLng은 필수값입니다.") Double swLng,
+    @NotNull(message = "neLat은 필수값입니다.") Double neLat,
+    @NotNull(message = "neLng은 필수값입니다.") Double neLng
+) {
+
+}

--- a/src/main/java/com/algangi/mongle/map/presentation/dto/MapObjectsResponse.java
+++ b/src/main/java/com/algangi/mongle/map/presentation/dto/MapObjectsResponse.java
@@ -1,0 +1,52 @@
+package com.algangi.mongle.map.presentation.dto;
+
+import java.util.Collections;
+import java.util.List;
+
+public record MapObjectsResponse(
+    List<Grain> grains,
+    List<StaticCloudInfo> staticClouds,
+    List<DynamicCloudInfo> dynamicClouds
+) {
+
+    public record Grain(
+        String postId,
+        double latitude,
+        double longitude,
+        String profileImageUrl
+    ) {
+
+    }
+
+    public record StaticCloudInfo(
+        String placeId,
+        String name,
+        double centerLatitude,
+        double centerLongitude,
+        long postCount,
+        List<Coordinate> polygon
+    ) {
+
+    }
+
+    public record DynamicCloudInfo(
+        String cloudId,
+        long postCount,
+        List<Coordinate> polygon
+    ) {
+
+    }
+
+    public record Coordinate(
+        double latitude,
+        double longitude
+    ) {
+
+    }
+
+    public static MapObjectsResponse empty() {
+        return new MapObjectsResponse(Collections.emptyList(), Collections.emptyList(),
+            Collections.emptyList());
+    }
+}
+

--- a/src/main/java/com/algangi/mongle/member/repository/MemberJpaRepository.java
+++ b/src/main/java/com/algangi/mongle/member/repository/MemberJpaRepository.java
@@ -3,6 +3,11 @@ package com.algangi.mongle.member.repository;
 import com.algangi.mongle.member.domain.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface MemberJpaRepository extends JpaRepository<Member, Long>{
+import java.util.List;
+
+public interface MemberJpaRepository extends JpaRepository<Member, Long> {
+
+    List<Member> findAllByMemberIdIn(List<Long> memberIds);
 
 }
+

--- a/src/main/java/com/algangi/mongle/member/service/MemberFinder.java
+++ b/src/main/java/com/algangi/mongle/member/service/MemberFinder.java
@@ -11,6 +11,8 @@ import com.algangi.mongle.global.exception.ApplicationException;
 
 import lombok.RequiredArgsConstructor;
 
+import java.util.List;
+
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true, propagation = Propagation.SUPPORTS)
@@ -20,7 +22,15 @@ public class MemberFinder {
 
     public Member getMemberOrThrow(Long memberId) {
         return memberJpaRepository.findById(memberId)
-                .orElseThrow(() -> new ApplicationException(MemberErrorCode.MEMBER_NOT_FOUND));
+            .orElseThrow(() -> new ApplicationException(MemberErrorCode.MEMBER_NOT_FOUND));
+    }
+
+    public List<Member> findMembersByIds(List<Long> memberIds) {
+        if (memberIds == null || memberIds.isEmpty()) {
+            return List.of();
+        }
+        return memberJpaRepository.findAllByMemberIdIn(memberIds);
     }
 
 }
+

--- a/src/main/java/com/algangi/mongle/post/application/service/PostQueryService.java
+++ b/src/main/java/com/algangi/mongle/post/application/service/PostQueryService.java
@@ -1,0 +1,61 @@
+package com.algangi.mongle.post.application.service;
+
+import com.algangi.mongle.member.domain.Member;
+import com.algangi.mongle.post.application.helper.PostFinder;
+import com.algangi.mongle.post.domain.model.Location;
+import com.algangi.mongle.post.domain.model.Post;
+import com.algangi.mongle.post.domain.repository.PostQueryRepository;
+import com.algangi.mongle.post.presentation.dto.PostDetailResponse;
+import com.algangi.mongle.post.presentation.dto.PostListRequest;
+import com.algangi.mongle.post.presentation.dto.PostListResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+import java.util.stream.IntStream;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class PostQueryService {
+
+    private final PostFinder postFinder;
+    private final PostQueryRepository postQueryRepository;
+
+    public PostListResponse getPostList(PostListRequest request) {
+        // TODO: PostQueryRepository를 사용하여 실제 DB에서 데이터 조회 로직 구현 필요.
+        // 현재는 임시 데이터를 생성하여 반환합니다.
+
+        List<PostListResponse.PostSummary> mockPosts = IntStream.range(0, request.size())
+            .mapToObj(i -> {
+                String postId = "post-" + UUID.randomUUID();
+                Post mockPost = Post.createStandalone(
+                    postId,
+                    Location.create(35.890, 128.611),
+                    "s2-token-example",
+                    "임시 게시글 제목 " + i,
+                    "임시 게시글 내용입니다. 필터링 조건: placeId=" + request.placeId() + ", cloudId="
+                        + request.cloudId(),
+                    1L // 임시 작성자 ID
+                );
+                return PostListResponse.PostSummary.withMockData(mockPost);
+            })
+            .toList();
+
+        String lastCursor =
+            (mockPosts.size() > 0) ? String.valueOf(System.currentTimeMillis()) : null;
+
+        return PostListResponse.of(mockPosts, lastCursor);
+    }
+
+    public PostDetailResponse getPostDetail(String postId) {
+        Post post = postFinder.getPostOrThrow(postId);
+
+        // TODO: post.getAuthorId()로 실제 작성자 조회, 파일 URL 생성 등 실제 데이터 기반으로 DTO를 생성해야 합니다.
+        // 현재는 임시 데이터를 생성하여 반환합니다.
+        return PostDetailResponse.withMockData(post);
+    }
+}

--- a/src/main/java/com/algangi/mongle/post/application/service/PostQueryService.java
+++ b/src/main/java/com/algangi/mongle/post/application/service/PostQueryService.java
@@ -1,20 +1,21 @@
 package com.algangi.mongle.post.application.service;
 
-import com.algangi.mongle.member.domain.Member;
+import com.algangi.mongle.comment.domain.repository.CommentQueryRepository;
 import com.algangi.mongle.post.application.helper.PostFinder;
 import com.algangi.mongle.post.domain.model.Location;
 import com.algangi.mongle.post.domain.model.Post;
 import com.algangi.mongle.post.domain.repository.PostQueryRepository;
-import com.algangi.mongle.post.presentation.dto.PostDetailResponse;
 import com.algangi.mongle.post.presentation.dto.PostListRequest;
 import com.algangi.mongle.post.presentation.dto.PostListResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.time.LocalDateTime;
+import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
+import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
 @Service
@@ -24,38 +25,45 @@ public class PostQueryService {
 
     private final PostFinder postFinder;
     private final PostQueryRepository postQueryRepository;
+    private final CommentQueryRepository commentQueryRepository;
 
     public PostListResponse getPostList(PostListRequest request) {
-        // TODO: PostQueryRepository를 사용하여 실제 DB에서 데이터 조회 로직 구현 필요.
+        // TODO: postQueryRepository를 사용하여 필터링/정렬/커서 기반의 실제 Post 목록 조회 로직 구현 필요.
         // 현재는 임시 데이터를 생성하여 반환합니다.
+        List<Post> posts = IntStream.range(0, request.size())
+            .mapToObj(i -> Post.createStandalone(
+                "post-" + UUID.randomUUID(),
+                Location.create(35.890, 128.611),
+                "s2-token-example",
+                "임시 게시글 제목 " + i,
+                "임시 게시글 내용입니다. 필터링 조건: placeId=" + request.placeId() + ", cloudId="
+                    + request.cloudId(),
+                1L // 임시 작성자 ID
+            ))
+            .toList();
 
-        List<PostListResponse.PostSummary> mockPosts = IntStream.range(0, request.size())
-            .mapToObj(i -> {
-                String postId = "post-" + UUID.randomUUID();
-                Post mockPost = Post.createStandalone(
-                    postId,
-                    Location.create(35.890, 128.611),
-                    "s2-token-example",
-                    "임시 게시글 제목 " + i,
-                    "임시 게시글 내용입니다. 필터링 조건: placeId=" + request.placeId() + ", cloudId="
-                        + request.cloudId(),
-                    1L // 임시 작성자 ID
-                );
-                return PostListResponse.PostSummary.withMockData(mockPost);
+        if (posts.isEmpty()) {
+            return PostListResponse.of(Collections.emptyList(), null);
+        }
+
+        // 1. 조회된 게시글 목록의 ID 추출
+        List<String> postIds = posts.stream().map(Post::getId).collect(Collectors.toList());
+
+        // 2. 게시글 ID 목록으로 댓글 수 Map을 한 번에 조회 (N+1 방지)
+        Map<String, Long> commentCounts = commentQueryRepository.countCommentsByPostIds(postIds);
+
+        // 3. Post와 댓글 수를 매핑하여 최종 DTO 생성
+        List<PostListResponse.PostSummary> postSummaries = posts.stream()
+            .map(post -> {
+                long count = commentCounts.getOrDefault(post.getId(), 0L);
+                return PostListResponse.PostSummary.from(post, count);
             })
             .toList();
 
-        String lastCursor =
-            (mockPosts.size() > 0) ? String.valueOf(System.currentTimeMillis()) : null;
+        // TODO: 실제 커서 로직 구현 필요
+        String lastCursor = (postSummaries.size() >= request.size()) ? "nextCursorExample" : null;
 
-        return PostListResponse.of(mockPosts, lastCursor);
-    }
-
-    public PostDetailResponse getPostDetail(String postId) {
-        Post post = postFinder.getPostOrThrow(postId);
-
-        // TODO: post.getAuthorId()로 실제 작성자 조회, 파일 URL 생성 등 실제 데이터 기반으로 DTO를 생성해야 합니다.
-        // 현재는 임시 데이터를 생성하여 반환합니다.
-        return PostDetailResponse.withMockData(post);
+        return PostListResponse.of(postSummaries, lastCursor);
     }
 }
+

--- a/src/main/java/com/algangi/mongle/post/application/service/PostQueryService.java
+++ b/src/main/java/com/algangi/mongle/post/application/service/PostQueryService.java
@@ -1,10 +1,14 @@
 package com.algangi.mongle.post.application.service;
 
 import com.algangi.mongle.comment.domain.repository.CommentQueryRepository;
+import com.algangi.mongle.global.application.service.ViewUrlIssueService;
+import com.algangi.mongle.member.domain.Member;
+import com.algangi.mongle.member.service.MemberFinder;
 import com.algangi.mongle.post.application.helper.PostFinder;
-import com.algangi.mongle.post.domain.model.Location;
 import com.algangi.mongle.post.domain.model.Post;
+import com.algangi.mongle.post.domain.model.PostFile;
 import com.algangi.mongle.post.domain.repository.PostQueryRepository;
+import com.algangi.mongle.post.presentation.dto.PostDetailResponse;
 import com.algangi.mongle.post.presentation.dto.PostListRequest;
 import com.algangi.mongle.post.presentation.dto.PostListResponse;
 import lombok.RequiredArgsConstructor;
@@ -14,9 +18,7 @@ import org.springframework.transaction.annotation.Transactional;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-import java.util.UUID;
 import java.util.stream.Collectors;
-import java.util.stream.IntStream;
 
 @Service
 @RequiredArgsConstructor
@@ -24,16 +26,18 @@ import java.util.stream.IntStream;
 public class PostQueryService {
 
     private final PostFinder postFinder;
+    private final MemberFinder memberFinder;
     private final PostQueryRepository postQueryRepository;
     private final CommentQueryRepository commentQueryRepository;
+    private final ViewUrlIssueService viewUrlIssueService; // 파일 URL 조회를 위해 주입
 
     public PostListResponse getPostList(PostListRequest request) {
         // TODO: postQueryRepository를 사용하여 필터링/정렬/커서 기반의 실제 Post 목록 조회 로직 구현 필요.
         // 현재는 임시 데이터를 생성하여 반환합니다.
-        List<Post> posts = IntStream.range(0, request.size())
+        List<Post> posts = java.util.stream.IntStream.range(0, request.size())
             .mapToObj(i -> Post.createStandalone(
-                "post-" + UUID.randomUUID(),
-                Location.create(35.890, 128.611),
+                "post-" + java.util.UUID.randomUUID(),
+                com.algangi.mongle.post.domain.model.Location.create(35.890, 128.611),
                 "s2-token-example",
                 "임시 게시글 제목 " + i,
                 "임시 게시글 내용입니다. 필터링 조건: placeId=" + request.placeId() + ", cloudId="
@@ -46,13 +50,9 @@ public class PostQueryService {
             return PostListResponse.of(Collections.emptyList(), null);
         }
 
-        // 1. 조회된 게시글 목록의 ID 추출
         List<String> postIds = posts.stream().map(Post::getId).collect(Collectors.toList());
-
-        // 2. 게시글 ID 목록으로 댓글 수 Map을 한 번에 조회 (N+1 방지)
         Map<String, Long> commentCounts = commentQueryRepository.countCommentsByPostIds(postIds);
 
-        // 3. Post와 댓글 수를 매핑하여 최종 DTO 생성
         List<PostListResponse.PostSummary> postSummaries = posts.stream()
             .map(post -> {
                 long count = commentCounts.getOrDefault(post.getId(), 0L);
@@ -60,10 +60,38 @@ public class PostQueryService {
             })
             .toList();
 
-        // TODO: 실제 커서 로직 구현 필요
         String lastCursor = (postSummaries.size() >= request.size()) ? "nextCursorExample" : null;
 
         return PostListResponse.of(postSummaries, lastCursor);
+    }
+
+    public PostDetailResponse getPostDetail(String postId) {
+        // 1. 게시글 조회 (없으면 예외 발생)
+        Post post = postFinder.getPostOrThrow(postId);
+
+        // 2. 작성자 정보 조회 (없으면 예외 발생)
+        Member author = memberFinder.getMemberOrThrow(post.getAuthorId());
+
+        // 3. 댓글 수 조회
+        long commentCount = commentQueryRepository.countByPostId(postId);
+
+        // 4. 첨부 파일 URL 조회 (임시 데이터)
+        // TODO: ViewUrlIssueService를 사용하여 실제 Presigned URL을 생성하는 로직으로 교체해야 합니다.
+        //  PostFile 엔티티에 파일 타입(이미지/비디오)을 구분할 수 있는 필드가 필요합니다.
+        List<String> photoUrls = post.getPostFiles().stream()
+            .map(PostFile::getFileKey)
+            // .filter(key -> key.contains("image")) // 실제로는 파일 확장자나 타입으로 구분해야 함
+            .map(key -> "https://picsum.photos/seed/" + key.substring(0, 10) + "/400/300")
+            .collect(Collectors.toList());
+
+        List<String> videoUrls = post.getPostFiles().stream()
+            .map(PostFile::getFileKey)
+            // .filter(key -> key.contains("video"))
+            .map(key -> "https://example.com/videos/sample_video.mp4")
+            .collect(Collectors.toList());
+
+        // 5. 최종 응답 DTO로 변환하여 반환
+        return PostDetailResponse.from(post, author, commentCount, photoUrls, videoUrls);
     }
 }
 

--- a/src/main/java/com/algangi/mongle/post/application/service/PostQueryService.java
+++ b/src/main/java/com/algangi/mongle/post/application/service/PostQueryService.java
@@ -2,6 +2,7 @@ package com.algangi.mongle.post.application.service;
 
 import com.algangi.mongle.comment.domain.repository.CommentQueryRepository;
 import com.algangi.mongle.global.application.service.ViewUrlIssueService;
+import com.algangi.mongle.global.util.DateTimeUtil;
 import com.algangi.mongle.member.domain.Member;
 import com.algangi.mongle.member.service.MemberFinder;
 import com.algangi.mongle.post.application.helper.PostFinder;
@@ -11,6 +12,8 @@ import com.algangi.mongle.post.domain.repository.PostQueryRepository;
 import com.algangi.mongle.post.presentation.dto.PostDetailResponse;
 import com.algangi.mongle.post.presentation.dto.PostListRequest;
 import com.algangi.mongle.post.presentation.dto.PostListResponse;
+import com.algangi.mongle.post.presentation.dto.PostSort;
+import com.algangi.mongle.post.presentation.dto.ViewUrlRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -18,6 +21,7 @@ import org.springframework.transaction.annotation.Transactional;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 
 @Service
@@ -27,71 +31,118 @@ public class PostQueryService {
 
     private final PostFinder postFinder;
     private final MemberFinder memberFinder;
-    private final PostQueryRepository postQueryRepository;
     private final CommentQueryRepository commentQueryRepository;
-    private final ViewUrlIssueService viewUrlIssueService; // 파일 URL 조회를 위해 주입
+    private final PostQueryRepository postQueryRepository;
+    private final ViewUrlIssueService viewUrlIssueService;
+
 
     public PostListResponse getPostList(PostListRequest request) {
-        // TODO: postQueryRepository를 사용하여 필터링/정렬/커서 기반의 실제 Post 목록 조회 로직 구현 필요.
-        // 현재는 임시 데이터를 생성하여 반환합니다.
-        List<Post> posts = java.util.stream.IntStream.range(0, request.size())
-            .mapToObj(i -> Post.createStandalone(
-                "post-" + java.util.UUID.randomUUID(),
-                com.algangi.mongle.post.domain.model.Location.create(35.890, 128.611),
-                "s2-token-example",
-                "임시 게시글 제목 " + i,
-                "임시 게시글 내용입니다. 필터링 조건: placeId=" + request.placeId() + ", cloudId="
-                    + request.cloudId(),
-                1L // 임시 작성자 ID
-            ))
-            .toList();
-
-        if (posts.isEmpty()) {
-            return PostListResponse.of(Collections.emptyList(), null);
+        List<Post> content = postQueryRepository.findPostsByCondition(request);
+        if (content.isEmpty()) {
+            return PostListResponse.empty();
         }
 
-        List<String> postIds = posts.stream().map(Post::getId).collect(Collectors.toList());
-        Map<String, Long> commentCounts = commentQueryRepository.countCommentsByPostIds(postIds);
+        Map<String, Long> commentCounts = getCommentCounts(content);
+        Map<Long, Member> authors = getAuthors(content);
+        Map<String, String> photoUrls = getFirstPhotoUrls(content);
 
-        List<PostListResponse.PostSummary> postSummaries = posts.stream()
-            .map(post -> {
-                long count = commentCounts.getOrDefault(post.getId(), 0L);
-                return PostListResponse.PostSummary.from(post, count);
-            })
-            .toList();
+        List<PostListResponse.PostSummary> summaries = content.stream().map(post -> {
+            Member author = authors.get(post.getAuthorId());
+            long commentCount = commentCounts.getOrDefault(post.getId(), 0L);
+            String photoUrl = photoUrls.get(post.getId());
+            List<String> photoUrlList =
+                photoUrl != null ? List.of(photoUrl) : Collections.emptyList();
 
-        String lastCursor = (postSummaries.size() >= request.size()) ? "nextCursorExample" : null;
+            return PostListResponse.PostSummary.from(post, author, commentCount, photoUrlList);
+        }).toList();
 
-        return PostListResponse.of(postSummaries, lastCursor);
+        String nextCursor = createNextCursor(content,
+            request.size() != null && content.size() > request.size(), request.sortBy());
+
+        return new PostListResponse(summaries, nextCursor, nextCursor != null);
     }
 
     public PostDetailResponse getPostDetail(String postId) {
-        // 1. 게시글 조회 (없으면 예외 발생)
         Post post = postFinder.getPostOrThrow(postId);
-
-        // 2. 작성자 정보 조회 (없으면 예외 발생)
         Member author = memberFinder.getMemberOrThrow(post.getAuthorId());
-
-        // 3. 댓글 수 조회
         long commentCount = commentQueryRepository.countByPostId(postId);
 
-        // 4. 첨부 파일 URL 조회 (임시 데이터)
-        // TODO: ViewUrlIssueService를 사용하여 실제 Presigned URL을 생성하는 로직으로 교체해야 합니다.
-        //  PostFile 엔티티에 파일 타입(이미지/비디오)을 구분할 수 있는 필드가 필요합니다.
-        List<String> photoUrls = post.getPostFiles().stream()
+        List<String> photoKeys = post.getPostFiles().stream()
             .map(PostFile::getFileKey)
-            // .filter(key -> key.contains("image")) // 실제로는 파일 확장자나 타입으로 구분해야 함
-            .map(key -> "https://picsum.photos/seed/" + key.substring(0, 10) + "/400/300")
-            .collect(Collectors.toList());
-
-        List<String> videoUrls = post.getPostFiles().stream()
+            .filter(key -> key.startsWith("posts/images/"))
+            .toList();
+        List<String> videoKeys = post.getPostFiles().stream()
             .map(PostFile::getFileKey)
-            // .filter(key -> key.contains("video"))
-            .map(key -> "https://example.com/videos/sample_video.mp4")
-            .collect(Collectors.toList());
+            .filter(key -> key.startsWith("posts/videos/"))
+            .toList();
 
-        // 5. 최종 응답 DTO로 변환하여 반환
+        List<String> photoUrls = issueFileUrls(photoKeys);
+        List<String> videoUrls = issueFileUrls(videoKeys);
+
+        // TODO: 조회수(viewCount)는 추후 구현 필요
         return PostDetailResponse.from(post, author, commentCount, photoUrls, videoUrls);
     }
-}
 
+
+    private Map<String, Long> getCommentCounts(List<Post> posts) {
+        List<String> postIds = posts.stream().map(Post::getId).toList();
+        return commentQueryRepository.countCommentsByPostIds(postIds);
+    }
+
+    private Map<Long, Member> getAuthors(List<Post> posts) {
+        List<Long> authorIds = posts.stream().map(Post::getAuthorId).distinct().toList();
+        return memberFinder.findMembersByIds(authorIds).stream()
+            .collect(Collectors.toMap(Member::getMemberId, Function.identity()));
+    }
+
+    private Map<String, String> getFirstPhotoUrls(List<Post> posts) {
+        List<String> firstPhotoKeys = posts.stream()
+            .map(p -> p.getPostFiles().stream()
+                .map(PostFile::getFileKey)
+                .filter(key -> key.startsWith("posts/images/"))
+                .findFirst()
+                .orElse(null))
+            .filter(key -> key != null)
+            .toList();
+
+        return issueFileUrlsToMap(firstPhotoKeys);
+    }
+
+    private List<String> issueFileUrls(List<String> fileKeys) {
+        if (fileKeys.isEmpty()) {
+            return Collections.emptyList();
+        }
+        return viewUrlIssueService.issueViewUrls(new ViewUrlRequest(fileKeys)).issuedUrls().stream()
+            .map(info -> info.presignedUrl())
+            .toList();
+    }
+
+    private Map<String, String> issueFileUrlsToMap(List<String> fileKeys) {
+        if (fileKeys.isEmpty()) {
+            return Collections.emptyMap();
+        }
+        return viewUrlIssueService.issueViewUrls(new ViewUrlRequest(fileKeys)).issuedUrls().stream()
+            .collect(Collectors.toMap(info -> info.fileKey(), info -> info.presignedUrl()));
+    }
+
+    private String createNextCursor(List<Post> content, boolean hasNext, PostSort sort) {
+        if (!hasNext) {
+            return null;
+        }
+
+        Post lastPost = content.get(content.size() - 1);
+        String formattedDate = lastPost.getCreatedDate().format(DateTimeUtil.CURSOR_DATE_FORMATTER);
+
+        if (sort == PostSort.ranking_score) {
+            return String.join("_",
+                String.valueOf(lastPost.getRankingScore()),
+                formattedDate,
+                lastPost.getId());
+        } else {
+            return String.join("_",
+                formattedDate,
+                lastPost.getId());
+        }
+    }
+
+}

--- a/src/main/java/com/algangi/mongle/post/domain/model/Post.java
+++ b/src/main/java/com/algangi/mongle/post/domain/model/Post.java
@@ -71,6 +71,7 @@ public class Post extends TimeBaseEntity {
     @CollectionTable(name = "post_file",
         joinColumns = @JoinColumn(name = "post_id"))
     @OrderColumn(name = "list_idx")
+    @Builder.Default
     private List<PostFile> postFiles = new ArrayList<>();
 
     @Column(nullable = false)

--- a/src/main/java/com/algangi/mongle/post/domain/repository/PostQueryRepository.java
+++ b/src/main/java/com/algangi/mongle/post/domain/repository/PostQueryRepository.java
@@ -8,12 +8,19 @@ import java.util.List;
 public interface PostQueryRepository {
 
     /**
-     * 조건에 따라 게시글 목록을 조회하는 동적 쿼리
+     * 게시글 목록을 조건에 따라 동적으로 조회합니다. (정렬, 필터링, 커서 기반 페이징)
      *
-     * @param request 필터링, 정렬, 커서, 페이지 사이즈 정보
-     * @return 조회된 Post 목록
+     * @param request 필터링 및 정렬 조건
+     * @return Post 목록
      */
     List<Post> findPostsByCondition(PostListRequest request);
 
+    /**
+     * 주어진 S2 Cell 목록 내에 있으면서, 구름에 속하지 않은 '알갱이' 상태의 게시글을 조회합니다.
+     *
+     * @param s2TokenIds S2 Cell 토큰 ID 목록
+     * @return 알갱이(Post) 목록
+     */
+    List<Post> findGrainsInCells(List<String> s2TokenIds);
 }
 

--- a/src/main/java/com/algangi/mongle/post/domain/repository/PostQueryRepository.java
+++ b/src/main/java/com/algangi/mongle/post/domain/repository/PostQueryRepository.java
@@ -4,23 +4,32 @@ import com.algangi.mongle.post.domain.model.Post;
 import com.algangi.mongle.post.presentation.dto.PostListRequest;
 
 import java.util.List;
+import java.util.Map;
 
 public interface PostQueryRepository {
 
     /**
-     * 게시글 목록을 조건에 따라 동적으로 조회합니다. (정렬, 필터링, 커서 기반 페이징)
-     *
-     * @param request 필터링 및 정렬 조건
-     * @return Post 목록
+     * 조건에 맞는 게시글 목록을 커서 기반으로 조회합니다.
      */
     List<Post> findPostsByCondition(PostListRequest request);
 
     /**
-     * 주어진 S2 Cell 목록 내에 있으면서, 구름에 속하지 않은 '알갱이' 상태의 게시글을 조회합니다.
-     *
-     * @param s2TokenIds S2 Cell 토큰 ID 목록
-     * @return 알갱이(Post) 목록
+     * 주어진 S2 Cell 목록 내에 '알갱이' 상태로 존재하는 게시글들을 조회합니다.
      */
-    List<Post> findGrainsInCells(List<String> s2TokenIds);
+    List<Post> findGrainsInCells(List<String> s2cellTokens);
+
+    /**
+     * 주어진 정적 구름 ID 목록에 대해 각 구름에 속한 게시글 수를 조회합니다.
+     *
+     * @return Map<CloudId, PostCount>
+     */
+    Map<Long, Long> countPostsByStaticCloudIds(List<Long> cloudIds);
+
+    /**
+     * 주어진 동적 구름 ID 목록에 대해 각 구름에 속한 게시글 수를 조회합니다.
+     *
+     * @return Map<CloudId, PostCount>
+     */
+    Map<Long, Long> countPostsByDynamicCloudIds(List<Long> cloudIds);
 }
 

--- a/src/main/java/com/algangi/mongle/post/domain/repository/PostQueryRepository.java
+++ b/src/main/java/com/algangi/mongle/post/domain/repository/PostQueryRepository.java
@@ -1,8 +1,19 @@
 package com.algangi.mongle.post.domain.repository;
 
 import com.algangi.mongle.post.domain.model.Post;
+import com.algangi.mongle.post.presentation.dto.PostListRequest;
+
 import java.util.List;
 
 public interface PostQueryRepository {
-    // TODO: 지도 객체 조회를 위한 메서드 추가 예정
+
+    /**
+     * 조건에 따라 게시글 목록을 조회하는 동적 쿼리
+     *
+     * @param request 필터링, 정렬, 커서, 페이지 사이즈 정보
+     * @return 조회된 Post 목록
+     */
+    List<Post> findPostsByCondition(PostListRequest request);
+
 }
+

--- a/src/main/java/com/algangi/mongle/post/domain/repository/PostQueryRepository.java
+++ b/src/main/java/com/algangi/mongle/post/domain/repository/PostQueryRepository.java
@@ -1,0 +1,8 @@
+package com.algangi.mongle.post.domain.repository;
+
+import com.algangi.mongle.post.domain.model.Post;
+import java.util.List;
+
+public interface PostQueryRepository {
+    // TODO: 지도 객체 조회를 위한 메서드 추가 예정
+}

--- a/src/main/java/com/algangi/mongle/post/infrastructure/persistence/PostQueryDslRepository.java
+++ b/src/main/java/com/algangi/mongle/post/infrastructure/persistence/PostQueryDslRepository.java
@@ -116,7 +116,7 @@ public class PostQueryDslRepository implements PostQueryRepository {
             if (parts.length != 3) {
                 return null;
             }
-            Double score = Double.parseDouble(parts[0]);
+            Double score = ParsingUtil.parse(parts[0], Double::parseDouble, "잘못된 커서 형식");
             LocalDateTime createdAt = ParsingUtil.parseDate(parts[1]);
             String id = parts[2];
 

--- a/src/main/java/com/algangi/mongle/post/infrastructure/persistence/PostQueryDslRepository.java
+++ b/src/main/java/com/algangi/mongle/post/infrastructure/persistence/PostQueryDslRepository.java
@@ -1,0 +1,15 @@
+package com.algangi.mongle.post.infrastructure.persistence;
+
+import com.algangi.mongle.post.domain.repository.PostQueryRepository;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class PostQueryDslRepository implements PostQueryRepository {
+
+    private final JPAQueryFactory queryFactory;
+
+    // TODO: 조회 메서드 구현 예정
+}

--- a/src/main/java/com/algangi/mongle/post/infrastructure/persistence/PostQueryDslRepository.java
+++ b/src/main/java/com/algangi/mongle/post/infrastructure/persistence/PostQueryDslRepository.java
@@ -1,9 +1,22 @@
 package com.algangi.mongle.post.infrastructure.persistence;
 
+import com.algangi.mongle.global.util.ParsingUtil;
+import com.algangi.mongle.post.domain.model.Post;
 import com.algangi.mongle.post.domain.repository.PostQueryRepository;
+import com.algangi.mongle.post.presentation.dto.PostListRequest;
+import com.algangi.mongle.post.presentation.dto.PostSort;
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.annotation.Nullable;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
+import org.springframework.util.StringUtils;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static com.algangi.mongle.post.domain.model.QPost.post;
 
 @Repository
 @RequiredArgsConstructor
@@ -11,5 +24,104 @@ public class PostQueryDslRepository implements PostQueryRepository {
 
     private final JPAQueryFactory queryFactory;
 
-    // TODO: 조회 메서드 구현 예정
+    @Override
+    public List<Post> findPostsByCondition(PostListRequest request) {
+        return queryFactory
+            .selectFrom(post)
+            .where(
+                eqPlaceId(request.placeId()),
+                eqCloudId(request.cloudId()),
+                cursorCondition(request.cursor(), request.sortBy())
+            )
+            .orderBy(orderSpecifiers(request.sortBy()))
+            .limit(request.size() + 1)
+            .fetch();
+    }
+
+    private BooleanExpression eqPlaceId(String placeId) {
+        if (!StringUtils.hasText(placeId)) {
+            return null;
+        }
+        try {
+            return post.staticCloudId.eq(Long.parseLong(placeId));
+        } catch (NumberFormatException e) {
+            return null;
+        }
+    }
+
+    private BooleanExpression eqCloudId(String cloudId) {
+        if (!StringUtils.hasText(cloudId)) {
+            return null;
+        }
+        try {
+            return post.dynamicCloudId.eq(Long.parseLong(cloudId));
+        } catch (NumberFormatException e) {
+            return null;
+        }
+    }
+
+    private OrderSpecifier<?>[] orderSpecifiers(@Nullable PostSort postSort) {
+        PostSort sort = (postSort == null) ? PostSort.ranking_score : postSort;
+
+        if (sort == PostSort.ranking_score) {
+            return new OrderSpecifier[]{
+                post.rankingScore.desc(),
+                post.createdDate.desc(),
+                post.id.desc()
+            };
+        }
+
+        return new OrderSpecifier[]{
+            post.createdDate.desc(),
+            post.id.desc()
+        };
+    }
+
+    private BooleanExpression cursorCondition(@Nullable String cursor,
+        @Nullable PostSort postSort) {
+        if (!StringUtils.hasText(cursor)) {
+            return null;
+        }
+
+        PostSort sort = (postSort == null) ? PostSort.ranking_score : postSort;
+
+        String[] parts = cursor.split("_");
+        if (sort == PostSort.ranking_score) {
+            if (parts.length != 3) {
+                return null;
+            }
+            try {
+                Double score = Double.parseDouble(parts[0]);
+                LocalDateTime createdAt = ParsingUtil.parseDate(parts[1]);
+                String id = parts[2];
+
+                return post.rankingScore.lt(score)
+                    .or(post.rankingScore.eq(score)
+                        .and(post.createdDate.lt(createdAt))
+                    ).or(post.rankingScore.eq(score)
+                        .and(post.createdDate.eq(createdAt))
+                        .and(post.id.lt(id))
+                    );
+            } catch (Exception e) {
+                return null;
+            }
+
+        } else {
+            if (parts.length != 2) {
+                return null;
+            }
+            try {
+                LocalDateTime createdAt = ParsingUtil.parseDate(parts[0]);
+                String id = parts[1];
+
+                return post.createdDate.lt(createdAt)
+                    .or(post.createdDate.eq(createdAt)
+                        .and(post.id.lt(id))
+                    );
+            } catch (Exception e) {
+                return null;
+            }
+        }
+    }
 }
+

--- a/src/main/java/com/algangi/mongle/post/presentation/controller/PostController.java
+++ b/src/main/java/com/algangi/mongle/post/presentation/controller/PostController.java
@@ -1,6 +1,12 @@
 package com.algangi.mongle.post.presentation.controller;
 
+import com.algangi.mongle.post.presentation.dto.PostDetailResponse;
+import com.algangi.mongle.post.presentation.dto.PostListRequest;
+import com.algangi.mongle.post.presentation.dto.PostListResponse;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -8,6 +14,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 import com.algangi.mongle.global.dto.ApiResponse;
 import com.algangi.mongle.post.application.service.PostCreationService;
+import com.algangi.mongle.post.application.service.PostQueryService;
 import com.algangi.mongle.post.presentation.dto.PostCreateRequest;
 import com.algangi.mongle.post.presentation.dto.PostResponse;
 
@@ -15,16 +22,34 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 
 @RestController
-@RequestMapping("/api/posts")
+@RequestMapping("/api")
 @RequiredArgsConstructor
 public class PostController {
 
     private final PostCreationService postCreationService;
+    private final PostQueryService postQueryService;
 
-    @PostMapping
+    @PostMapping("/posts")
     public ResponseEntity<ApiResponse<PostResponse>> createPost(
         @Valid @RequestBody PostCreateRequest dto) {
-
         return ResponseEntity.ok(ApiResponse.success(postCreationService.createPost(dto)));
     }
+
+    @GetMapping("/posts")
+    public ResponseEntity<ApiResponse<PostListResponse>> getPostList(
+        @ModelAttribute @Valid PostListRequest request) {
+        PostListResponse response = postQueryService.getPostList(request);
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    // 아래 메서드는 Commit 3에서 사용될 예정입니다.
+    @GetMapping("/posts/{postId}")
+    public ResponseEntity<ApiResponse<PostDetailResponse>> getPostDetail(
+        @PathVariable String postId) {
+        // TODO: Commit 3에서 상세 조회 로직 구현 예정. 현재는 임시 응답 반환.
+        // PostDetailResponse response = postQueryService.getPostDetail(postId);
+        // return ResponseEntity.ok(ApiResponse.success("게시글 상세 조회에 성공했습니다.", response));
+        return ResponseEntity.ok(ApiResponse.success(null));
+    }
 }
+

--- a/src/main/java/com/algangi/mongle/post/presentation/controller/PostController.java
+++ b/src/main/java/com/algangi/mongle/post/presentation/controller/PostController.java
@@ -1,8 +1,15 @@
 package com.algangi.mongle.post.presentation.controller;
 
+import com.algangi.mongle.global.dto.ApiResponse;
+import com.algangi.mongle.post.application.service.PostCreationService;
+import com.algangi.mongle.post.application.service.PostQueryService;
+import com.algangi.mongle.post.presentation.dto.PostCreateRequest;
 import com.algangi.mongle.post.presentation.dto.PostDetailResponse;
 import com.algangi.mongle.post.presentation.dto.PostListRequest;
 import com.algangi.mongle.post.presentation.dto.PostListResponse;
+import com.algangi.mongle.post.presentation.dto.PostResponse;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
@@ -12,15 +19,6 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-import com.algangi.mongle.global.dto.ApiResponse;
-import com.algangi.mongle.post.application.service.PostCreationService;
-import com.algangi.mongle.post.application.service.PostQueryService;
-import com.algangi.mongle.post.presentation.dto.PostCreateRequest;
-import com.algangi.mongle.post.presentation.dto.PostResponse;
-
-import jakarta.validation.Valid;
-import lombok.RequiredArgsConstructor;
-
 @RestController
 @RequestMapping("/api")
 @RequiredArgsConstructor
@@ -29,19 +27,23 @@ public class PostController {
     private final PostCreationService postCreationService;
     private final PostQueryService postQueryService;
 
+    // 게시글 생성
     @PostMapping("/posts")
     public ResponseEntity<ApiResponse<PostResponse>> createPost(
         @Valid @RequestBody PostCreateRequest dto) {
-        return ResponseEntity.ok(ApiResponse.success(postCreationService.createPost(dto)));
+        PostResponse response = postCreationService.createPost(dto);
+        return ResponseEntity.ok(ApiResponse.success(response));
     }
 
+    // 게시글 목록 조회 (정적/동적 구름 내부)
     @GetMapping("/posts")
     public ResponseEntity<ApiResponse<PostListResponse>> getPostList(
-        @ModelAttribute @Valid PostListRequest request) {
+        @Valid @ModelAttribute PostListRequest request) {
         PostListResponse response = postQueryService.getPostList(request);
         return ResponseEntity.ok(ApiResponse.success(response));
     }
 
+    // 게시글 상세 조회
     @GetMapping("/posts/{postId}")
     public ResponseEntity<ApiResponse<PostDetailResponse>> getPostDetail(
         @PathVariable String postId) {

--- a/src/main/java/com/algangi/mongle/post/presentation/controller/PostController.java
+++ b/src/main/java/com/algangi/mongle/post/presentation/controller/PostController.java
@@ -42,14 +42,11 @@ public class PostController {
         return ResponseEntity.ok(ApiResponse.success(response));
     }
 
-    // 아래 메서드는 Commit 3에서 사용될 예정입니다.
     @GetMapping("/posts/{postId}")
     public ResponseEntity<ApiResponse<PostDetailResponse>> getPostDetail(
         @PathVariable String postId) {
-        // TODO: Commit 3에서 상세 조회 로직 구현 예정. 현재는 임시 응답 반환.
-        // PostDetailResponse response = postQueryService.getPostDetail(postId);
-        // return ResponseEntity.ok(ApiResponse.success("게시글 상세 조회에 성공했습니다.", response));
-        return ResponseEntity.ok(ApiResponse.success(null));
+        PostDetailResponse response = postQueryService.getPostDetail(postId);
+        return ResponseEntity.ok(ApiResponse.success(response));
     }
 }
 

--- a/src/main/java/com/algangi/mongle/post/presentation/dto/PostDetailResponse.java
+++ b/src/main/java/com/algangi/mongle/post/presentation/dto/PostDetailResponse.java
@@ -2,12 +2,10 @@ package com.algangi.mongle.post.presentation.dto;
 
 import com.algangi.mongle.member.domain.Member;
 import com.algangi.mongle.post.domain.model.Post;
-import lombok.Builder;
 
 import java.time.LocalDateTime;
 import java.util.List;
 
-@Builder
 public record PostDetailResponse(
     String postId,
     Author author,
@@ -17,13 +15,12 @@ public record PostDetailResponse(
     List<String> photoUrls,
     List<String> videoUrls,
     LocalDateTime createdAt,
-    long viewCount,
+    long viewCount, // TODO: 조회수 기능 구현 필요
     long likeCount,
     long dislikeCount,
     long commentCount
 ) {
 
-    @Builder
     public record Author(
         String id,
         String nickname,
@@ -31,31 +28,33 @@ public record PostDetailResponse(
     ) {
 
         public static Author from(Member member) {
-            // TODO: Member 엔티티에 profileImageUrl 필드 추가 시 반영 필요
-            return Author.builder()
-                .id(member.getMemberId().toString())
-                .nickname(member.getNickname())
-                .profileImageUrl("https://i.pravatar.cc/150?u=" + member.getMemberId()) // 임시 URL
-                .build();
+            if (member == null) {
+                return new Author(null, "익명의 몽글러", null);
+            }
+            return new Author(
+                member.getMemberId().toString(),
+                member.getNickname(),
+                member.getProfileImage()
+            );
         }
     }
 
     public static PostDetailResponse from(Post post, Member author, long commentCount,
         List<String> photoUrls, List<String> videoUrls) {
-        return PostDetailResponse.builder()
-            .postId(post.getId())
-            .author(Author.from(author))
-            .content(post.getContent())
-            .latitude(post.getLocation().getLatitude())
-            .longitude(post.getLocation().getLongitude())
-            .photoUrls(photoUrls)
-            .videoUrls(videoUrls)
-            .createdAt(post.getCreatedDate())
-            .viewCount(0) // TODO: 조회수 기능 구현 필요
-            .likeCount(post.getLikeCount())
-            .dislikeCount(post.getDislikeCount())
-            .commentCount(commentCount)
-            .build();
+        return new PostDetailResponse(
+            post.getId(),
+            Author.from(author),
+            post.getContent(),
+            post.getLocation().getLatitude(),
+            post.getLocation().getLongitude(),
+            photoUrls,
+            videoUrls,
+            post.getCreatedDate(),
+            0, // TODO: 조회수 기능 구현 후 반영
+            post.getLikeCount(),
+            post.getDislikeCount(),
+            commentCount
+        );
     }
 }
 

--- a/src/main/java/com/algangi/mongle/post/presentation/dto/PostDetailResponse.java
+++ b/src/main/java/com/algangi/mongle/post/presentation/dto/PostDetailResponse.java
@@ -1,0 +1,61 @@
+package com.algangi.mongle.post.presentation.dto;
+
+import com.algangi.mongle.member.domain.Member;
+import com.algangi.mongle.post.domain.model.Post;
+import lombok.Builder;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Builder
+public record PostDetailResponse(
+    String postId,
+    Author author,
+    String content,
+    double latitude,
+    double longitude,
+    List<String> photoUrls,
+    List<String> videoUrls,
+    LocalDateTime createdAt,
+    long viewCount,
+    long likeCount,
+    long dislikeCount,
+    long commentCount
+) {
+
+    @Builder
+    public record Author(
+        String id,
+        String nickname,
+        String profileImageUrl
+    ) {
+
+        public static Author from(Member member) {
+            // TODO: Member 엔티티에 profileImageUrl 필드 추가 시 반영 필요
+            return Author.builder()
+                .id(member.getMemberId().toString())
+                .nickname(member.getNickname())
+                .profileImageUrl("https://i.pravatar.cc/150?u=" + member.getMemberId()) // 임시 URL
+                .build();
+        }
+    }
+
+    public static PostDetailResponse from(Post post, Member author, long commentCount,
+        List<String> photoUrls, List<String> videoUrls) {
+        return PostDetailResponse.builder()
+            .postId(post.getId())
+            .author(Author.from(author))
+            .content(post.getContent())
+            .latitude(post.getLocation().getLatitude())
+            .longitude(post.getLocation().getLongitude())
+            .photoUrls(photoUrls)
+            .videoUrls(videoUrls)
+            .createdAt(post.getCreatedDate())
+            .viewCount(0) // TODO: 조회수 기능 구현 필요
+            .likeCount(post.getLikeCount())
+            .dislikeCount(post.getDislikeCount())
+            .commentCount(commentCount)
+            .build();
+    }
+}
+

--- a/src/main/java/com/algangi/mongle/post/presentation/dto/PostListRequest.java
+++ b/src/main/java/com/algangi/mongle/post/presentation/dto/PostListRequest.java
@@ -1,0 +1,25 @@
+package com.algangi.mongle.post.presentation.dto;
+
+import java.util.Optional;
+
+public record PostListRequest(
+    String placeId,
+    String cloudId,
+    PostSort sortBy,
+    String cursor,
+    Integer size
+) {
+
+    private static final int DEFAULT_SIZE = 10;
+    private static final int MAX_SIZE = 50;
+
+    public PostSort sortBy() {
+        return Optional.ofNullable(sortBy).orElse(PostSort.createdAt);
+    }
+
+    public int size() {
+        return Optional.ofNullable(size)
+            .map(s -> Math.min(s, MAX_SIZE))
+            .orElse(DEFAULT_SIZE);
+    }
+}

--- a/src/main/java/com/algangi/mongle/post/presentation/dto/PostListRequest.java
+++ b/src/main/java/com/algangi/mongle/post/presentation/dto/PostListRequest.java
@@ -5,21 +5,23 @@ import java.util.Optional;
 public record PostListRequest(
     String placeId,
     String cloudId,
-    PostSort sortBy,
     String cursor,
-    Integer size
+    Integer size,
+    PostSort sortBy
 ) {
 
     private static final int DEFAULT_SIZE = 10;
     private static final int MAX_SIZE = 50;
 
     public PostSort sortBy() {
-        return Optional.ofNullable(sortBy).orElse(PostSort.createdAt);
+        return Optional.ofNullable(sortBy).orElse(PostSort.ranking_score);
     }
 
     public Integer size() {
-        return Optional.ofNullable(size)
-            .map(s -> Math.min(s, MAX_SIZE))
-            .orElse(DEFAULT_SIZE);
+        if (size == null || size <= 0) {
+            return DEFAULT_SIZE;
+        }
+        return Math.min(size, MAX_SIZE);
     }
 }
+

--- a/src/main/java/com/algangi/mongle/post/presentation/dto/PostListRequest.java
+++ b/src/main/java/com/algangi/mongle/post/presentation/dto/PostListRequest.java
@@ -17,7 +17,7 @@ public record PostListRequest(
         return Optional.ofNullable(sortBy).orElse(PostSort.createdAt);
     }
 
-    public int size() {
+    public Integer size() {
         return Optional.ofNullable(size)
             .map(s -> Math.min(s, MAX_SIZE))
             .orElse(DEFAULT_SIZE);

--- a/src/main/java/com/algangi/mongle/post/presentation/dto/PostListResponse.java
+++ b/src/main/java/com/algangi/mongle/post/presentation/dto/PostListResponse.java
@@ -1,0 +1,53 @@
+package com.algangi.mongle.post.presentation.dto;
+
+import com.algangi.mongle.post.domain.model.Post;
+import java.time.LocalDateTime;
+import java.util.List;
+import lombok.Builder;
+
+@Builder
+public record PostListResponse(
+    List<PostSummary> posts,
+    String lastCursor
+) {
+
+    public static PostListResponse of(List<PostSummary> posts, String lastCursor) {
+        return new PostListResponse(posts, lastCursor);
+    }
+
+    @Builder
+    public record PostSummary(
+        String postId,
+        String authorNickname,
+        String content,
+        List<String> photoUrls,
+        List<String> videoUrls,
+        long upvotes,
+        long downvotes,
+        long commentCount,
+        LocalDateTime createdAt
+    ) {
+
+        public static PostSummary from(Post post, long commentCount) {
+            // TODO: 실제 Member 정보를 조회하여 닉네임 설정
+            String nickname = "익명의 몽글러";
+
+            // TODO: 실제 PostFile 정보를 기반으로 photoUrls, videoUrls 생성
+            List<String> photos = List.of(
+                "https://picsum.photos/seed/" + post.getId() + "/400/300");
+            List<String> videos = List.of();
+
+            return new PostSummary(
+                post.getId(),
+                nickname,
+                post.getContent(),
+                photos,
+                videos,
+                post.getLikeCount(),
+                post.getDislikeCount(),
+                commentCount,
+                post.getCreatedDate()
+            );
+        }
+    }
+}

--- a/src/main/java/com/algangi/mongle/post/presentation/dto/PostListResponse.java
+++ b/src/main/java/com/algangi/mongle/post/presentation/dto/PostListResponse.java
@@ -1,48 +1,51 @@
 package com.algangi.mongle.post.presentation.dto;
 
+import com.algangi.mongle.member.domain.Member;
 import com.algangi.mongle.post.domain.model.Post;
+import lombok.Getter;
+
 import java.time.LocalDateTime;
+import java.util.Collections;
 import java.util.List;
-import lombok.Builder;
 
-@Builder
-public record PostListResponse(
-    List<PostSummary> posts,
-    String lastCursor
-) {
+@Getter
+public class PostListResponse {
 
-    public static PostListResponse of(List<PostSummary> posts, String lastCursor) {
-        return new PostListResponse(posts, lastCursor);
+    private final List<PostSummary> posts;
+    private final String nextCursor;
+    private final boolean hasNext;
+
+    public PostListResponse(List<PostSummary> posts, String nextCursor, boolean hasNext) {
+        this.posts = posts;
+        this.nextCursor = nextCursor;
+        this.hasNext = hasNext;
     }
 
-    @Builder
+    public static PostListResponse empty() {
+        return new PostListResponse(Collections.emptyList(), null, false);
+    }
+
     public record PostSummary(
         String postId,
         String authorNickname,
         String content,
         List<String> photoUrls,
-        List<String> videoUrls,
         long upvotes,
         long downvotes,
         long commentCount,
         LocalDateTime createdAt
     ) {
 
-        public static PostSummary from(Post post, long commentCount) {
-            // TODO: 실제 Member 정보를 조회하여 닉네임 설정
-            String nickname = "익명의 몽글러";
-
-            // TODO: 실제 PostFile 정보를 기반으로 photoUrls, videoUrls 생성
-            List<String> photos = List.of(
-                "https://picsum.photos/seed/" + post.getId() + "/400/300");
-            List<String> videos = List.of();
+        public static PostSummary from(Post post, Member author, long commentCount,
+            List<String> photoUrls) {
+            String nickname =
+                (author != null) ? author.getNickname() : "익명의 몽글러"; // author가 null일 경우 대비
 
             return new PostSummary(
                 post.getId(),
                 nickname,
                 post.getContent(),
-                photos,
-                videos,
+                photoUrls,
                 post.getLikeCount(),
                 post.getDislikeCount(),
                 commentCount,
@@ -51,3 +54,4 @@ public record PostListResponse(
         }
     }
 }
+

--- a/src/main/java/com/algangi/mongle/post/presentation/dto/PostSort.java
+++ b/src/main/java/com/algangi/mongle/post/presentation/dto/PostSort.java
@@ -1,0 +1,6 @@
+package com.algangi.mongle.post.presentation.dto;
+
+public enum PostSort {
+    ranking_score,
+    createdAt
+}

--- a/src/main/java/com/algangi/mongle/staticCloud/repository/StaticCloudRepository.java
+++ b/src/main/java/com/algangi/mongle/staticCloud/repository/StaticCloudRepository.java
@@ -1,12 +1,12 @@
 package com.algangi.mongle.staticCloud.repository;
 
-import java.util.Optional;
-
+import com.algangi.mongle.staticCloud.domain.model.StaticCloud;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
-import com.algangi.mongle.staticCloud.domain.model.StaticCloud;
+import java.util.List;
+import java.util.Optional;
 
 public interface StaticCloudRepository extends JpaRepository<StaticCloud, Long> {
 
@@ -14,4 +14,14 @@ public interface StaticCloudRepository extends JpaRepository<StaticCloud, Long> 
 
     @Query("select sc from StaticCloud sc join sc.s2TokenIds s2TokenId where s2TokenId = :s2TokenId")
     Optional<StaticCloud> findByS2TokenId(@Param("s2TokenId") String s2TokenId);
+
+    /**
+     * 주어진 S2 Cell 목록과 겹치는 정적 구름을 모두 조회합니다.
+     *
+     * @param s2TokenIds S2 Cell 토큰 ID 목록
+     * @return 정적 구름(StaticCloud) 목록
+     */
+    @Query("select DISTINCT sc from StaticCloud sc join sc.s2TokenIds s2TokenId where s2TokenId in :s2TokenIds")
+    List<StaticCloud> findCloudsInCells(@Param("s2TokenIds") List<String> s2TokenIds);
 }
+

--- a/src/main/java/com/algangi/mongle/staticCloud/repository/StaticCloudRepository.java
+++ b/src/main/java/com/algangi/mongle/staticCloud/repository/StaticCloudRepository.java
@@ -1,6 +1,7 @@
 package com.algangi.mongle.staticCloud.repository;
 
 import com.algangi.mongle.staticCloud.domain.model.StaticCloud;
+import java.util.Set;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;

--- a/src/main/java/com/algangi/mongle/staticCloud/repository/StaticCloudRepository.java
+++ b/src/main/java/com/algangi/mongle/staticCloud/repository/StaticCloudRepository.java
@@ -15,13 +15,7 @@ public interface StaticCloudRepository extends JpaRepository<StaticCloud, Long> 
     @Query("select sc from StaticCloud sc join sc.s2TokenIds s2TokenId where s2TokenId = :s2TokenId")
     Optional<StaticCloud> findByS2TokenId(@Param("s2TokenId") String s2TokenId);
 
-    /**
-     * 주어진 S2 Cell 목록과 겹치는 정적 구름을 모두 조회합니다.
-     *
-     * @param s2TokenIds S2 Cell 토큰 ID 목록
-     * @return 정적 구름(StaticCloud) 목록
-     */
-    @Query("select DISTINCT sc from StaticCloud sc join sc.s2TokenIds s2TokenId where s2TokenId in :s2TokenIds")
-    List<StaticCloud> findCloudsInCells(@Param("s2TokenIds") List<String> s2TokenIds);
+    // 주어진 S2 Cell 목록과 겹치는 정적 구름들을 조회
+    @Query("select distinct sc from StaticCloud sc join sc.s2TokenIds s2TokenId where s2TokenId in :s2cellTokens")
+    List<StaticCloud> findCloudsInCells(@Param("s2cellTokens") List<String> s2cellTokens);
 }
-


### PR DESCRIPTION
## 📄Summary

- 게시글 목록 조회 API (GET /api/posts)
  - placeId(정적 구름), cloudId(동적 구름)를 이용한 필터링 기능을 구현했습니다.
  - sortBy 파라미터(createdAt, ranking_score)를 통해 최신순, 인기순 정렬이 가능합니다. (ranking_score가 기본값)
  - 커서 기반 페이지네이션을 구현하여 무한 스크롤에 대응할 수 있도록 했습니다.
- 게시글 상세 조회 API (GET /api/posts/{postId})
  - 특정 게시글의 상세 정보와 작성자 정보, 미디어(사진/비디오) URL, 댓글 수를 포함하여 반환합니다.
- 지도 객체 조회 API (GET /api/map/objects)
  - 남서/북동쪽 위경도 좌표를 받아 해당 사각 영역 내에 존재하는 모든 객체(알갱이, 정적/동적 구름)를 조회합니다.
  - S2 라이브러리를 연동하여 지도 범위 내의 객체를 효율적으로 필터링합니다.

<br><br>

## 🙋🏻 More
Postman으로 api 동작을 테스트 해보고 싶어 도커 컨테이너를 실행했으나 몽글 앱이 실행, 정지를 반복하고 있습니다.
로그를 확인하니 db 주소를 못 찾아 연결을 못하고 있다는데 .env 파일을 디스코드에 있는 것과 똑같이 했는데 무슨 문제인지 잘모르겠습니다.😭
[링크 클릭 시 녹화본으로 이동](https://youtu.be/Cu3o4foVK4g)

<img width="1418" height="358" alt="image" src="https://github.com/user-attachments/assets/ec5c9e69-cc2b-4069-86e2-955aee894167" />
빌드에는 성공했습니다.

<br><br>

## 🔗관련 이슈
- Close #5 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 지도 객체 조회 API 추가: GET /api/map/objects (영역 내 그레인·정적·동적 클라우드 반환, 폴리곤 및 게시글 수 포함).
  * 게시글 조회 API 추가: GET /api/posts(목록, 필터/정렬/커서) 및 GET /api/posts/{postId}(상세, 작성자·미디어·댓글 수).

* **개선**
  * 지도 처리 정확도 향상: S2 셀 범위 및 폴리곤 변환 추가.
  * 댓글·게시글 집계 및 회원 조회 안정성·성능 개선.

* **API 변경**
  * Post API 기본 경로를 /api로 정리.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->