### PR TITLE
Feature/29 Redis + Lua 스크립트 적용 및 Service 연동

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -62,6 +62,8 @@ dependencies {
     implementation("io.awspring.cloud:spring-cloud-aws-starter-s3:3.1.1")
     // AWS CloudFront 연동을 위한 SDK
     implementation("software.amazon.awssdk:cloudfront")
+    // redis
+    implementation("org.springframework.boot:spring-boot-starter-data-redis")
 }
 
 tasks.withType<Test> {

--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -5,6 +5,8 @@ services:
     depends_on:
       db:
         condition: service_healthy
+      redis:
+        condition: service_healthy
     ports:
       - "8080:8080"
     env_file:
@@ -32,6 +34,20 @@ services:
       - --collation-server=utf8mb4_unicode_ci
     healthcheck:
       test: [ "CMD", "mysqladmin" ,"ping", "-h", "localhost", "-u", "${DB_USER}", "-p${DB_PASSWORD}" ]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+  redis:
+    image: redis:7.2-alpine
+    container_name: my-redis
+    ports:
+      - "6379:6379"
+    command: redis-server --appendonly yes
+    networks:
+      - mongle-net
+    healthcheck:
+      test: [ "CMD", "redis-cli", "ping" ]
       interval: 10s
       timeout: 5s
       retries: 5

--- a/src/main/java/com/algangi/mongle/comment/application/service/CommentCommandService.java
+++ b/src/main/java/com/algangi/mongle/comment/application/service/CommentCommandService.java
@@ -1,5 +1,6 @@
 package com.algangi.mongle.comment.application.service;
 
+import com.algangi.mongle.stats.application.service.ContentStatsService;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -23,6 +24,7 @@ public class CommentCommandService {
     private final CommentFinder commentFinder;
     private final CommentDomainService commentDomainService;
     private final CommentRepository commentRepository;
+    private final ContentStatsService contentStatsService;
 
     @Transactional
     public void createParentComment(String postId, String content, String memberId) {
@@ -32,6 +34,7 @@ public class CommentCommandService {
         Comment newComment = commentDomainService.createParentComment(post, author, content);
 
         commentRepository.save(newComment);
+        contentStatsService.incrementPostCommentCount(postId);
     }
 
     @Transactional
@@ -42,6 +45,7 @@ public class CommentCommandService {
         Comment newComment = commentDomainService.createChildComment(parent, author, content);
 
         commentRepository.save(newComment);
+        contentStatsService.incrementPostCommentCount(parent.getPost().getId());
     }
 
     @Transactional
@@ -49,6 +53,7 @@ public class CommentCommandService {
         Comment comment = commentFinder.getCommentOrThrow(commentId);
 
         commentDomainService.deleteComment(comment);
+        contentStatsService.decrementPostCommentCount(comment.getPost().getId());
     }
 
 }

--- a/src/main/java/com/algangi/mongle/comment/application/service/CommentCommandService.java
+++ b/src/main/java/com/algangi/mongle/comment/application/service/CommentCommandService.java
@@ -25,7 +25,7 @@ public class CommentCommandService {
     private final CommentRepository commentRepository;
 
     @Transactional
-    public void createParentComment(String postId, String content, Long memberId) {
+    public void createParentComment(String postId, String content, String memberId) {
         Member author = memberFinder.getMemberOrThrow(memberId);
         Post post = postFinder.getPostOrThrow(postId);
 
@@ -35,7 +35,7 @@ public class CommentCommandService {
     }
 
     @Transactional
-    public void createChildComment(Long parentCommentId, String content, Long memberId) {
+    public void createChildComment(String parentCommentId, String content, String memberId) {
         Member author = memberFinder.getMemberOrThrow(memberId);
         Comment parent = commentFinder.getCommentOrThrow(parentCommentId);
 
@@ -45,7 +45,7 @@ public class CommentCommandService {
     }
 
     @Transactional
-    public void deleteComment(Long commentId) {
+    public void deleteComment(String commentId) {
         Comment comment = commentFinder.getCommentOrThrow(commentId);
 
         commentDomainService.deleteComment(comment);

--- a/src/main/java/com/algangi/mongle/comment/application/service/CommentQueryService.java
+++ b/src/main/java/com/algangi/mongle/comment/application/service/CommentQueryService.java
@@ -34,7 +34,7 @@ public class CommentQueryService {
     private static final int MAX_PAGE_SIZE = 50;
 
     public CursorInfoResponse<CommentInfoResponse> getCommentsByPost(
-            CommentSearchCondition condition, Long currentMemberId, int pageSize) {
+            CommentSearchCondition condition, String currentMemberId, int pageSize) {
         // 1. 게시글 존재 확인
         postFinder.getPostOrThrow(condition.postId());
 
@@ -45,7 +45,7 @@ public class CommentQueryService {
         PaginationResult<Comment> pageResult = commentQueryRepository.findCommentsByPost(condition, adjustedSize);
 
         // 4. 각 댓글의 대댓글 존재 여부 Map<댓글ID, Boolean> 형태로 조회
-        Map<Long, Boolean> hasRepliesMap = getHasRepliesMap(pageResult.content());
+        Map<String, Boolean> hasRepliesMap = getHasRepliesMap(pageResult.content());
 
         // 5. 커서 생성
         String nextCursor = createNextCursor(pageResult.content(), pageResult.hasNext(), condition.sort());
@@ -62,7 +62,7 @@ public class CommentQueryService {
     }
 
     public CursorInfoResponse<ReplyInfoResponse> getRepliesByParent(
-            ReplySearchCondition condition, Long currentMemberId, int pageSize) {
+            ReplySearchCondition condition, String currentMemberId, int pageSize) {
         // 1. 부모 댓글 존재 확인
         commentFinder.getCommentOrThrow(condition.parentId());
 
@@ -85,10 +85,10 @@ public class CommentQueryService {
         return CursorInfoResponse.of(responses, nextCursor, pageResult.hasNext());
     }
 
-    private Map<Long, Boolean> getHasRepliesMap(List<Comment> comments) {
+    private Map<String, Boolean> getHasRepliesMap(List<Comment> comments) {
         if (comments.isEmpty()) return Map.of();
 
-        List<Long> parentIds = comments.stream()
+        List<String> parentIds = comments.stream()
                 .map(Comment::getId)
                 .toList();
         return commentQueryRepository.findHasRepliesByParentIds(parentIds);
@@ -108,8 +108,8 @@ public class CommentQueryService {
                 .format(DateTimeUtil.CURSOR_DATE_FORMATTER);
 
         return switch (sort) {
-            case LIKES -> String.format("%d_%s_%d", lastItem.getLikeCount(), formattedDate, lastItem.getId());
-            case LATEST -> String.format("%s_%d", formattedDate, lastItem.getId());
+            case LIKES -> String.format("%d_%s_%s", lastItem.getLikeCount(), formattedDate, lastItem.getId());
+            case LATEST -> String.format("%s_%s", formattedDate, lastItem.getId());
         };
     }
 }

--- a/src/main/java/com/algangi/mongle/comment/domain/model/Comment.java
+++ b/src/main/java/com/algangi/mongle/comment/domain/model/Comment.java
@@ -33,7 +33,7 @@ public class Comment extends TimeBaseEntity implements CursorConvertible {
     @Id
     @Tsid
     @Column(nullable = false, updatable = false)
-    private Long id;
+    private String id;
 
     @Column(nullable = false)
     private String content;
@@ -109,7 +109,7 @@ public class Comment extends TimeBaseEntity implements CursorConvertible {
     }
 
     @Override
-    public Long getId() {
+    public String getId() {
         return this.id;
     }
 

--- a/src/main/java/com/algangi/mongle/comment/domain/model/CursorConvertible.java
+++ b/src/main/java/com/algangi/mongle/comment/domain/model/CursorConvertible.java
@@ -3,7 +3,7 @@ package com.algangi.mongle.comment.domain.model;
 import java.time.LocalDateTime;
 
 public interface CursorConvertible {
-    Long getId();
+    String getId();
     long getLikeCount();
     LocalDateTime getCreatedAt();
 }

--- a/src/main/java/com/algangi/mongle/comment/domain/repository/CommentQueryRepository.java
+++ b/src/main/java/com/algangi/mongle/comment/domain/repository/CommentQueryRepository.java
@@ -14,7 +14,7 @@ public interface CommentQueryRepository {
 
     PaginationResult<Comment> findRepliesByParent(ReplySearchCondition condition, int size);
 
-    Map<Long, Boolean> findHasRepliesByParentIds(List<Long> parentIds);
+    Map<String, Boolean> findHasRepliesByParentIds(List<String> parentIds);
 
     long countByPostId(String postId);
 

--- a/src/main/java/com/algangi/mongle/comment/domain/repository/CommentRepository.java
+++ b/src/main/java/com/algangi/mongle/comment/domain/repository/CommentRepository.java
@@ -3,6 +3,6 @@ package com.algangi.mongle.comment.domain.repository;
 import com.algangi.mongle.comment.domain.model.Comment;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface CommentRepository extends JpaRepository<Comment, Long> {
+public interface CommentRepository extends JpaRepository<Comment, String> {
 
 }

--- a/src/main/java/com/algangi/mongle/comment/domain/service/CommentFinder.java
+++ b/src/main/java/com/algangi/mongle/comment/domain/service/CommentFinder.java
@@ -16,7 +16,7 @@ public class CommentFinder {
 
     private final CommentRepository commentJpaRepository;
 
-    public Comment getCommentOrThrow(Long commentId) {
+    public Comment getCommentOrThrow(String commentId) {
         return commentJpaRepository.findById(commentId)
                 .orElseThrow(() -> new ApplicationException(CommentErrorCode.COMMENT_NOT_FOUND));
     }

--- a/src/main/java/com/algangi/mongle/comment/infrastructure/persistence/CommentQueryDslRepository.java
+++ b/src/main/java/com/algangi/mongle/comment/infrastructure/persistence/CommentQueryDslRepository.java
@@ -67,13 +67,13 @@ public class CommentQueryDslRepository implements CommentQueryRepository {
     }
 
     @Override
-    public Map<Long, Boolean> findHasRepliesByParentIds(List<Long> parentIds) {
+    public Map<String, Boolean> findHasRepliesByParentIds(List<String> parentIds) {
         if (parentIds.isEmpty()) {
             return Collections.emptyMap();
         }
 
         QComment reply = new QComment("reply");
-        List<Long> parentIdsWithReplies = queryFactory
+        List<String> parentIdsWithReplies = queryFactory
             .select(reply.parentComment.id)
             .from(reply)
             .where(
@@ -83,7 +83,7 @@ public class CommentQueryDslRepository implements CommentQueryRepository {
             .groupBy(reply.parentComment.id)
             .fetch();
 
-        Set<Long> parentIdsWithRepliesSet = new HashSet<>(parentIdsWithReplies);
+        Set<String> parentIdsWithRepliesSet = new HashSet<>(parentIdsWithReplies);
         return parentIds.stream()
             .collect(Collectors.toMap(
                 id -> id,

--- a/src/main/java/com/algangi/mongle/comment/infrastructure/persistence/querydsl/CommentCursorParser.java
+++ b/src/main/java/com/algangi/mongle/comment/infrastructure/persistence/querydsl/CommentCursorParser.java
@@ -27,7 +27,7 @@ public class CommentCursorParser {
             throw new IllegalArgumentException("잘못된 커서 형식: " + String.join("_", parts));
 
         var created = ParsingUtil.parseDate(parts[0]);
-        var id = ParsingUtil.parseLong(parts[1]);
+        String id = parts[1];
 
         return comment.createdDate.lt(created)
                 .or(
@@ -41,7 +41,7 @@ public class CommentCursorParser {
 
         var like = ParsingUtil.parseLong(parts[0]);
         var created = ParsingUtil.parseDate(parts[1]);
-        var id = ParsingUtil.parseLong(parts[2]);
+        String id = parts[2];
 
         return comment.likeCount.lt(like)
                 .or(

--- a/src/main/java/com/algangi/mongle/comment/infrastructure/persistence/querydsl/CommentFilterFactory.java
+++ b/src/main/java/com/algangi/mongle/comment/infrastructure/persistence/querydsl/CommentFilterFactory.java
@@ -19,7 +19,7 @@ public class CommentFilterFactory {
         return comment.post.id.eq(postId);
     }
 
-    public BooleanExpression eqParentId(Long parentId) {
+    public BooleanExpression eqParentId(String parentId) {
         if (parentId == null) {
             return null;
         }

--- a/src/main/java/com/algangi/mongle/comment/infrastructure/persistence/vo/ReplySearchCondition.java
+++ b/src/main/java/com/algangi/mongle/comment/infrastructure/persistence/vo/ReplySearchCondition.java
@@ -3,7 +3,7 @@ package com.algangi.mongle.comment.infrastructure.persistence.vo;
 import com.algangi.mongle.comment.domain.model.CommentSort;
 
 public record ReplySearchCondition(
-        Long parentId,
+        String parentId,
         String cursor,
         CommentSort sort
 ) {

--- a/src/main/java/com/algangi/mongle/comment/presentation/controller/CommentController.java
+++ b/src/main/java/com/algangi/mongle/comment/presentation/controller/CommentController.java
@@ -35,22 +35,22 @@ public class CommentController {
 
     @GetMapping("/posts/{postId}/comments")
     public ResponseEntity<ApiResponse<CursorInfoResponse<CommentInfoResponse>>> getCommentsByPost(
-        @PathVariable(name = "postId") String postId,
-        @ModelAttribute CommentQueryRequest request,
-        @RequestParam Long memberId) {
+            @PathVariable(name = "postId") String postId,
+            @ModelAttribute CommentQueryRequest request
+    ) {
         var condition = commentRequestMapper.toPostCommentSearchCondition(postId, request);
-        var result = commentQueryService.getCommentsByPost(condition, memberId, request.size());
+        var result = commentQueryService.getCommentsByPost(condition, request.memberId(), request.size());
 
         return ResponseEntity.ok(ApiResponse.success(result));
     }
 
     @GetMapping("/comments/{parentCommentId}/replies")
     public ResponseEntity<ApiResponse<CursorInfoResponse<ReplyInfoResponse>>> getRepliesByParent(
-        @PathVariable(name = "parentCommentId") Long parentCommentId,
-        @ModelAttribute CommentQueryRequest request,
-        @RequestParam Long memberId) {
+            @PathVariable(name = "parentCommentId") String parentCommentId,
+            @ModelAttribute CommentQueryRequest request
+    ) {
         var condition = commentRequestMapper.toReplySearchCondition(parentCommentId, request);
-        var result = commentQueryService.getRepliesByParent(condition, memberId, request.size());
+        var result = commentQueryService.getRepliesByParent(condition, request.memberId(), request.size());
 
         return ResponseEntity.ok(ApiResponse.success(result));
     }
@@ -59,23 +59,23 @@ public class CommentController {
     public ResponseEntity<ApiResponse<Void>> createParentComment(
         @PathVariable(name = "postId") String postId,
         @Valid @RequestBody CommentCreateRequest dto,
-        @RequestParam Long memberId) {
+        @RequestParam String memberId)  {
         commentCommandService.createParentComment(postId, dto.content(), memberId);
         return ResponseEntity.ok(ApiResponse.success());
     }
 
     @PostMapping("/comments/{parentCommentId}/replies")
     public ResponseEntity<ApiResponse<Void>> createChildComment(
-        @PathVariable(name = "parentCommentId") Long parentCommentId,
-        @Valid @RequestBody CommentCreateRequest dto,
-        @RequestParam Long memberId) {
+            @PathVariable(name = "parentCommentId") String parentCommentId,
+            @Valid @RequestBody CommentCreateRequest dto,
+            @RequestParam String memberId) {
         commentCommandService.createChildComment(parentCommentId, dto.content(), memberId);
         return ResponseEntity.ok(ApiResponse.success());
     }
 
     @DeleteMapping("/comments/{commentId}")
     public ResponseEntity<ApiResponse<Void>> deleteComment(
-        @PathVariable(name = "commentId") Long commentId) {
+            @PathVariable(name = "commentId") String commentId) {
         commentCommandService.deleteComment(commentId);
         return ResponseEntity.ok(ApiResponse.success());
     }

--- a/src/main/java/com/algangi/mongle/comment/presentation/dto/CommentQueryRequest.java
+++ b/src/main/java/com/algangi/mongle/comment/presentation/dto/CommentQueryRequest.java
@@ -6,7 +6,7 @@ public record CommentQueryRequest(
         String cursor,
         Integer size,
         CommentSort sort,
-        Long memberId
+        String memberId
 ) {
 
     private static final int DEFAULT_SIZE = 10;

--- a/src/main/java/com/algangi/mongle/comment/presentation/mapper/CommentRequestMapper.java
+++ b/src/main/java/com/algangi/mongle/comment/presentation/mapper/CommentRequestMapper.java
@@ -14,7 +14,7 @@ public class CommentRequestMapper {
         return new CommentSearchCondition(postId, request.cursor(), request.sort());
     }
 
-    public ReplySearchCondition toReplySearchCondition(Long parentId, CommentQueryRequest request) {
+    public ReplySearchCondition toReplySearchCondition(String parentId, CommentQueryRequest request) {
         return new ReplySearchCondition(parentId, request.cursor(), request.sort());
     }
 

--- a/src/main/java/com/algangi/mongle/comment/presentation/mapper/CommentResponseMapper.java
+++ b/src/main/java/com/algangi/mongle/comment/presentation/mapper/CommentResponseMapper.java
@@ -19,12 +19,12 @@ public final class CommentResponseMapper {
     private static final String MASKED_NICKNAME = "(알 수 없음)";
     private static final String DEFAULT_PROFILE_IMAGE_URL = "default_profile_image_url";
 
-    public CommentInfoResponse toCommentInfoResponse(Comment comment, Long currentMemberId, boolean hasReplies) {
+    public CommentInfoResponse toCommentInfoResponse(Comment comment, String currentMemberId, boolean hasReplies) {
         boolean deleted = comment.isDeleted();
         Member author = comment.getMember();
 
         return new CommentInfoResponse(
-                comment.getId().toString(),
+                comment.getId(),
                 mapContent(comment, deleted),
                 mapAuthor(author, deleted),
                 mapLikeCount(comment, deleted),
@@ -36,12 +36,12 @@ public final class CommentResponseMapper {
         );
     }
 
-    public ReplyInfoResponse toReplyInfoResponse(Comment reply, Long currentMemberId) {
+    public ReplyInfoResponse toReplyInfoResponse(Comment reply, String currentMemberId) {
         boolean deleted = reply.isDeleted();
         Member author = reply.getMember();
 
         return new ReplyInfoResponse(
-                reply.getId().toString(),
+                reply.getId(),
                 mapContent(reply, deleted),
                 mapAuthor(author, deleted),
                 mapLikeCount(reply, deleted),
@@ -62,13 +62,13 @@ public final class CommentResponseMapper {
         }
 
         return new AuthorInfoResponse(
-                author.getMemberId().toString(),
+                author.getMemberId(),
                 author.getNickname(),
                 author.getProfileImage()
         );
     }
 
-    private boolean mapIsAuthor(Member author, Long currentMemberId, boolean deleted) {
+    private boolean mapIsAuthor(Member author, String currentMemberId, boolean deleted) {
         return !deleted
                 && author != null
                 && Objects.equals(author.getMemberId(), currentMemberId);

--- a/src/main/java/com/algangi/mongle/global/config/RedisConfig.java
+++ b/src/main/java/com/algangi/mongle/global/config/RedisConfig.java
@@ -1,0 +1,42 @@
+package com.algangi.mongle.global.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.script.DefaultRedisScript;
+import org.springframework.data.redis.core.script.RedisScript;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+import org.springframework.scripting.support.ResourceScriptSource;
+
+import java.util.List;
+
+@Configuration
+public class RedisConfig {
+
+    @Bean
+    public RedisTemplate<String, String> redisTemplate(RedisConnectionFactory connectionFactory) {
+        RedisTemplate<String, String> template = new RedisTemplate<>();
+        template.setConnectionFactory(connectionFactory);
+
+        template.setKeySerializer(new StringRedisSerializer());
+        template.setValueSerializer(new StringRedisSerializer());
+        template.setHashKeySerializer(new StringRedisSerializer());
+        template.setHashValueSerializer(new StringRedisSerializer());
+
+        return template;
+    }
+
+    @Bean
+    @SuppressWarnings("rawtypes")
+    public RedisScript<List> reactionScript() {
+        ClassPathResource scriptResource = new ClassPathResource("redis/reaction.lua");
+
+        DefaultRedisScript<List> redisScript = new DefaultRedisScript<>();
+        redisScript.setScriptSource(new ResourceScriptSource(scriptResource));
+
+        redisScript.setResultType(List.class);
+        return redisScript;
+    }
+}

--- a/src/main/java/com/algangi/mongle/map/application/service/MapQueryService.java
+++ b/src/main/java/com/algangi/mongle/map/application/service/MapQueryService.java
@@ -51,7 +51,7 @@ public class MapQueryService {
             s2cellTokens);
 
         // 3. 조회된 객체들에 필요한 추가 정보를 조회합니다.
-        Map<Long, Member> authors = getAuthors(grains);
+        Map<String, Member> authors = getAuthors(grains);
         Map<Long, Long> staticCloudPostCounts = getStaticCloudPostCounts(staticClouds);
         Map<Long, Long> dynamicCloudPostCounts = getDynamicCloudPostCounts(dynamicClouds);
 
@@ -76,7 +76,7 @@ public class MapQueryService {
                 cloud.getLatitude(),
                 cloud.getLongitude(),
                 staticCloudPostCounts.getOrDefault(cloud.getId(), 0L),
-                s2PolygonConverter.convertS2TokensToPolygon(cloud.getS2TokenIds())
+                s2PolygonConverter.convert(cloud.getS2TokenIds())
             ))
             .toList();
 
@@ -84,18 +84,18 @@ public class MapQueryService {
             .map(cloud -> new MapObjectsResponse.DynamicCloudInfo(
                 cloud.getId().toString(),
                 dynamicCloudPostCounts.getOrDefault(cloud.getId(), 0L),
-                s2PolygonConverter.convertS2TokensToPolygon(cloud.getS2TokenIds())
+                s2PolygonConverter.convert(cloud.getS2TokenIds())
             ))
             .toList();
 
         return new MapObjectsResponse(grainDtos, staticCloudDtos, dynamicCloudDtos);
     }
 
-    private Map<Long, Member> getAuthors(List<Post> grains) {
+    private Map<String, Member> getAuthors(List<Post> grains) {
         if (grains.isEmpty()) {
             return Collections.emptyMap();
         }
-        List<Long> authorIds = grains.stream()
+        List<String> authorIds = grains.stream()
             .map(Post::getAuthorId)
             .distinct()
             .toList();

--- a/src/main/java/com/algangi/mongle/member/domain/Member.java
+++ b/src/main/java/com/algangi/mongle/member/domain/Member.java
@@ -22,7 +22,7 @@ public class Member extends TimeBaseEntity {
 
     @Id
     @Tsid
-    Long memberId;
+    String memberId;
 
     @Column(nullable = false, unique = true)
     String email;

--- a/src/main/java/com/algangi/mongle/member/repository/MemberJpaRepository.java
+++ b/src/main/java/com/algangi/mongle/member/repository/MemberJpaRepository.java
@@ -5,9 +5,8 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
 
-public interface MemberJpaRepository extends JpaRepository<Member, Long> {
+public interface MemberJpaRepository extends JpaRepository<Member, String> {
 
-    List<Member> findAllByMemberIdIn(List<Long> memberIds);
+    List<Member> findAllByMemberIdIn(List<String> memberIds);
 
 }
-

--- a/src/main/java/com/algangi/mongle/member/service/MemberFinder.java
+++ b/src/main/java/com/algangi/mongle/member/service/MemberFinder.java
@@ -20,12 +20,12 @@ public class MemberFinder {
 
     private final MemberJpaRepository memberJpaRepository;
 
-    public Member getMemberOrThrow(Long memberId) {
+    public Member getMemberOrThrow(String  memberId) {
         return memberJpaRepository.findById(memberId)
             .orElseThrow(() -> new ApplicationException(MemberErrorCode.MEMBER_NOT_FOUND));
     }
 
-    public List<Member> findMembersByIds(List<Long> memberIds) {
+    public List<Member> findMembersByIds(List<String> memberIds) {
         if (memberIds == null || memberIds.isEmpty()) {
             return List.of();
         }

--- a/src/main/java/com/algangi/mongle/post/application/dto/PostCreationCommand.java
+++ b/src/main/java/com/algangi/mongle/post/application/dto/PostCreationCommand.java
@@ -8,11 +8,11 @@ public record PostCreationCommand(
     String s2TokenId,
     String title,
     String content,
-    Long authorId
+    String authorId
 ) {
 
     public static PostCreationCommand of(String id, Location location, String s2TokenId,
-        String title, String content, Long authorId) {
+        String title, String content, String authorId) {
         return new PostCreationCommand(id, location, s2TokenId, title, content, authorId);
     }
 

--- a/src/main/java/com/algangi/mongle/post/application/service/PostQueryService.java
+++ b/src/main/java/com/algangi/mongle/post/application/service/PostQueryService.java
@@ -51,7 +51,7 @@ public class PostQueryService {
 
         // 3. 잘라낸 'postsOnPage'를 기준으로 후속 작업을 처리하여 불필요한 연산을 방지
         Map<String, Long> commentCounts = getCommentCounts(postsOnPage);
-        Map<Long, Member> authors = getAuthors(postsOnPage);
+        Map<String, Member> authors = getAuthors(postsOnPage);
         Map<String, String> photoUrls = getFirstPhotoUrls(postsOnPage); // postId -> URL 맵
 
         // 4. DTO 조립
@@ -100,8 +100,8 @@ public class PostQueryService {
         return commentQueryRepository.countCommentsByPostIds(postIds);
     }
 
-    private Map<Long, Member> getAuthors(List<Post> posts) {
-        List<Long> authorIds = posts.stream().map(Post::getAuthorId).distinct().toList();
+    private Map<String, Member> getAuthors(List<Post> posts) {
+        List<String> authorIds = posts.stream().map(Post::getAuthorId).distinct().toList();
         if (authorIds.isEmpty()) {
             return Collections.emptyMap();
         }

--- a/src/main/java/com/algangi/mongle/post/domain/model/Post.java
+++ b/src/main/java/com/algangi/mongle/post/domain/model/Post.java
@@ -75,7 +75,7 @@ public class Post extends TimeBaseEntity {
     private List<PostFile> postFiles = new ArrayList<>();
 
     @Column(nullable = false)
-    private Long authorId;
+    private String authorId;
 
     private Long dynamicCloudId;
 
@@ -91,7 +91,7 @@ public class Post extends TimeBaseEntity {
         String s2TokenId,
         String title,
         String content,
-        Long authorId,
+        String authorId,
         Long staticCloudId
     ) {
         return Post.builder()
@@ -111,7 +111,7 @@ public class Post extends TimeBaseEntity {
         String s2TokenId,
         String title,
         String content,
-        Long authorId,
+        String authorId,
         Long dynamicCloudId
     ) {
         return Post.builder()
@@ -131,7 +131,7 @@ public class Post extends TimeBaseEntity {
         String s2TokenId,
         String title,
         String content,
-        Long authorId
+        String authorId
     ) {
         return Post.builder()
             .id(postId)

--- a/src/main/java/com/algangi/mongle/post/presentation/dto/PostCreateRequest.java
+++ b/src/main/java/com/algangi/mongle/post/presentation/dto/PostCreateRequest.java
@@ -20,7 +20,7 @@ public record PostCreateRequest(
     @Size(max = 2000)
     String content,
     @NotNull(message = "작성자 ID는 필수값입니다.")
-    Long authorId,//인증 도입 시 제거 예정
+    String authorId,//인증 도입 시 제거 예정
     List<String> fileKeyList
 ) {
     

--- a/src/main/java/com/algangi/mongle/post/presentation/dto/PostResponse.java
+++ b/src/main/java/com/algangi/mongle/post/presentation/dto/PostResponse.java
@@ -8,7 +8,7 @@ public record PostResponse(
     String id,
     String title,
     String content,
-    Long authorId,
+    String authorId,
     String s2TokenId,
     Long staticCloudId,
     Long dynamicCloudId,

--- a/src/main/java/com/algangi/mongle/reaction/application/service/ReactionApplicationService.java
+++ b/src/main/java/com/algangi/mongle/reaction/application/service/ReactionApplicationService.java
@@ -1,0 +1,38 @@
+package com.algangi.mongle.reaction.application.service;
+
+
+import com.algangi.mongle.comment.domain.service.CommentFinder;
+import com.algangi.mongle.post.application.helper.PostFinder;
+import com.algangi.mongle.reaction.domain.model.ReactionType;
+import com.algangi.mongle.reaction.domain.model.TargetType;
+import com.algangi.mongle.reaction.presentation.dto.ReactionResponse;
+import com.algangi.mongle.stats.application.service.ContentStatsService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class ReactionApplicationService {
+
+    private final ContentStatsService contentStatsService;
+    private final PostFinder postFinder;
+    private final CommentFinder commentFinder;
+
+    @Transactional(readOnly = true)
+    public ReactionResponse updateReaction(String targetTypeStr, String targetId, String memberId, ReactionType reactionType) {
+        TargetType targetType = TargetType.from(targetTypeStr);
+        validateTargetExists(targetType, targetId);
+
+        return contentStatsService.updateReaction(targetType, targetId, memberId, reactionType);
+    }
+
+    private void validateTargetExists(TargetType targetType, String targetId) {
+        switch (targetType) {
+            case POST -> postFinder.getPostOrThrow(targetId);
+            case COMMENT -> commentFinder.getCommentOrThrow(targetId);
+            default -> throw new IllegalStateException("유효하지 않은 targetType 입니다: " + targetType);
+        }
+    }
+
+}

--- a/src/main/java/com/algangi/mongle/reaction/domain/TargetType.java
+++ b/src/main/java/com/algangi/mongle/reaction/domain/TargetType.java
@@ -1,6 +1,0 @@
-package com.algangi.mongle.reaction.domain;
-
-public enum TargetType {
-    POST,
-    COMMENT
-}

--- a/src/main/java/com/algangi/mongle/reaction/domain/model/Reaction.java
+++ b/src/main/java/com/algangi/mongle/reaction/domain/model/Reaction.java
@@ -1,4 +1,4 @@
-package com.algangi.mongle.reaction.domain;
+package com.algangi.mongle.reaction.domain.model;
 
 import com.algangi.mongle.global.entity.CreatedDateBaseEntity;
 import com.algangi.mongle.member.domain.Member;

--- a/src/main/java/com/algangi/mongle/reaction/domain/model/ReactionType.java
+++ b/src/main/java/com/algangi/mongle/reaction/domain/model/ReactionType.java
@@ -1,4 +1,4 @@
-package com.algangi.mongle.reaction.domain;
+package com.algangi.mongle.reaction.domain.model;
 
 public enum ReactionType {
     LIKE,

--- a/src/main/java/com/algangi/mongle/reaction/domain/model/TargetType.java
+++ b/src/main/java/com/algangi/mongle/reaction/domain/model/TargetType.java
@@ -1,0 +1,29 @@
+package com.algangi.mongle.reaction.domain.model;
+
+import java.util.Arrays;
+
+public enum TargetType {
+    POST("post"),
+    COMMENT("comment");
+
+    private final String lowerCase;
+
+    TargetType(String lowerCase) {
+        this.lowerCase = lowerCase;
+    }
+
+    public String getLowerCase() {
+        return lowerCase;
+    }
+
+    public static TargetType from(String value) {
+        String preparedValue = value.toUpperCase().endsWith("S")
+                ? value.toUpperCase().substring(0, value.length() - 1)
+                : value.toUpperCase();
+
+        return Arrays.stream(values())
+                .filter(type -> type.name().equals(preparedValue))
+                .findFirst()
+                .orElseThrow(() -> new IllegalArgumentException("유효하지 않은 targetType 입니다: " + value));
+    }
+}

--- a/src/main/java/com/algangi/mongle/reaction/presentation/controller/ReactionController.java
+++ b/src/main/java/com/algangi/mongle/reaction/presentation/controller/ReactionController.java
@@ -1,0 +1,35 @@
+package com.algangi.mongle.reaction.presentation.controller;
+
+import com.algangi.mongle.global.dto.ApiResponse;
+import com.algangi.mongle.reaction.application.service.ReactionApplicationService;
+import com.algangi.mongle.reaction.presentation.dto.ReactionRequest;
+import com.algangi.mongle.reaction.presentation.dto.ReactionResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api")
+@RequiredArgsConstructor
+public class ReactionController {
+
+    private final ReactionApplicationService reactionApplicationService;
+
+    @PostMapping("/{targetType}/{targetId}/reaction")
+    public ResponseEntity<ApiResponse<ReactionResponse>> updateReaction(
+            @PathVariable String targetType,
+            @PathVariable String targetId,
+            @RequestBody ReactionRequest request,
+            @RequestParam String memberId
+    ) {
+        ReactionResponse result = reactionApplicationService.updateReaction(
+                targetType,
+                targetId,
+                memberId,
+                request.reactionType()
+        );
+
+        return ResponseEntity.ok(ApiResponse.success(result));
+    }
+
+}

--- a/src/main/java/com/algangi/mongle/reaction/presentation/dto/ReactionRequest.java
+++ b/src/main/java/com/algangi/mongle/reaction/presentation/dto/ReactionRequest.java
@@ -1,0 +1,9 @@
+package com.algangi.mongle.reaction.presentation.dto;
+
+import com.algangi.mongle.reaction.domain.model.ReactionType;
+
+public record ReactionRequest(
+        ReactionType reactionType
+) {
+
+}

--- a/src/main/java/com/algangi/mongle/reaction/presentation/dto/ReactionResponse.java
+++ b/src/main/java/com/algangi/mongle/reaction/presentation/dto/ReactionResponse.java
@@ -1,0 +1,8 @@
+package com.algangi.mongle.reaction.presentation.dto;
+
+public record ReactionResponse(
+        long likeCount,
+        long dislikeCount
+) {
+
+}

--- a/src/main/java/com/algangi/mongle/stats/application/service/ContentStatsService.java
+++ b/src/main/java/com/algangi/mongle/stats/application/service/ContentStatsService.java
@@ -1,0 +1,70 @@
+package com.algangi.mongle.stats.application.service;
+
+import com.algangi.mongle.reaction.domain.model.ReactionType;
+import com.algangi.mongle.reaction.domain.model.TargetType;
+import com.algangi.mongle.reaction.presentation.dto.ReactionResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.script.RedisScript;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@SuppressWarnings({"rawtypes", "unchecked"})
+public class ContentStatsService {
+
+    private final RedisTemplate<String, String> redisTemplate;
+    private final RedisScript<List> reactionScript;
+
+    private static final String VIEW_COUNT_KEY_PREFIX = "views::";
+    private static final String COMMENT_COUNT_KEY_PREFIX = "comments::";
+    private static final String LIKES_COUNT_KEY_PREFIX = "likes::";
+    private static final String DISLIKES_COUNT_KEY_PREFIX = "dislikes::";
+    private static final String REACTIONS_KEY_PREFIX = "reactions::";
+
+    private String getKey(String prefix, TargetType targetType, String targetId) {
+        return prefix + targetType.getLowerCase() + "::" + targetId;
+    }
+
+    public Long incrementPostViewCount(String postId) {
+        String key = getKey(VIEW_COUNT_KEY_PREFIX, TargetType.POST, postId);
+        return redisTemplate.opsForValue().increment(key);
+    }
+
+    public void incrementPostCommentCount(String postId) {
+        String key = COMMENT_COUNT_KEY_PREFIX + "post::" + postId;
+        redisTemplate.opsForValue().increment(key);
+    }
+
+    public void decrementPostCommentCount(String postId) {
+        String key = COMMENT_COUNT_KEY_PREFIX + "post::" + postId;
+        redisTemplate.opsForValue().decrement(key);
+    }
+
+    public ReactionResponse updateReaction(TargetType targetType, String targetId, String memberId, ReactionType reactionType) {
+        List<String> keys = List.of(
+                getKey(REACTIONS_KEY_PREFIX, targetType, targetId),
+                getKey(LIKES_COUNT_KEY_PREFIX, targetType, targetId),
+                getKey(DISLIKES_COUNT_KEY_PREFIX, targetType, targetId)
+        );
+
+        Object[] args = { memberId, reactionType.name() };
+
+        List<Object> result = (List<Object>) redisTemplate.execute(reactionScript, keys, args);
+
+        if (result.size() < 2) {
+            throw new IllegalStateException("Lua 스크립트 실행 결과가 올바르지 않습니다.");
+        }
+
+        long likeCount = result.get(0) != null
+                ? Long.parseLong(result.get(0).toString())
+                : 0L;
+        long dislikeCount = result.get(1) != null
+                ? Long.parseLong(result.get(1).toString())
+                : 0L;
+
+        return new ReactionResponse(likeCount, dislikeCount);
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -15,6 +15,10 @@ spring:
   sql:
     init:
       mode: always
+  data:
+    redis:
+      host: ${REDIS_HOST:localhost}
+      port: ${REDIS_PORT:6379}
   cloud:
     aws:
       credentials:

--- a/src/main/resources/redis/reaction.lua
+++ b/src/main/resources/redis/reaction.lua
@@ -1,0 +1,50 @@
+-- 인자 값 변수 할당
+local reactionsKey = KEYS[1]
+local likesCountKey = KEYS[2]
+local dislikesCountKey = KEYS[3]
+
+local memberId = ARGV[1]
+local newReaction = ARGV[2]
+
+-- 사용자의 현재 리액션 상태 조회
+local currentReaction = redis.call('HGET', reactionsKey, memberId)
+
+-- 1. 같은 리액션을 다시 클릭한 경우
+if currentReaction == newReaction then
+  redis.call('HDEL', reactionsKey, memberId)
+
+  if newReaction == 'LIKE' then
+    redis.call('DECR', likesCountKey)
+  else
+    redis.call('DECR', dislikesCountKey)
+  end
+
+-- 2. 다른 리액션으로 변경한 경우
+elseif currentReaction then
+  redis.call('HSET', reactionsKey, memberId, newReaction)
+
+  if newReaction == 'LIKE' then
+    redis.call('DECR', dislikesCountKey)
+    redis.call('INCR', likesCountKey)
+  else
+    redis.call('DECR', likesCountKey)
+    redis.call('INCR', dislikesCountKey)
+  end
+
+-- 3. 아무 리액션도 없던 경우
+else
+  redis.call('HSET', reactionsKey, memberId, newReaction)
+
+  if newReaction == 'LIKE' then
+    redis.call('INCR', likesCountKey)
+  else
+    redis.call('INCR', dislikesCountKey)
+  end
+end
+
+-- 최종 좋아요/싫어요 수 조회
+local finalLikes = redis.call('GET', likesCountKey) or 0
+local finalDislikes = redis.call('GET', dislikesCountKey) or 0
+
+-- 최종 카운트를 배열로 반환
+return { finalLikes, finalDislikes }


### PR DESCRIPTION
## 📄Summary
- Lua 스크립트를 작성하여 Redis에서 원자적 연산을 수행하고,
이를 Service 레이어에 연결하여 애플리케이션에서 사용할 수 있도록 하였습니다.

<br><br>

## 🙋🏻 More
- Member Id를 String으로 바꿔서 오류나는 부분은 임의로 수정하였습니다.
- convertS2TokensToPolygon가 없다는 오류가 나서 그냥 converter로 임의로 수정하였습니다.
- 리액션 정책
  - 같은 거 또 누른 경우 → 취소 (좋아요/싫어요 -1 하고, 기록 삭제)
  - 다른 거로 바꾼 경우 → 이전 거 -1, 새 거 +1
  - 처음 누른 경우 → 그냥 새로 +1

<br><br>

## 🔗관련 이슈
- Close #29 
