### PR TITLE
Feat/38 조회 api 개선

### DIFF
--- a/src/main/java/com/algangi/mongle/map/application/service/MapQueryService.java
+++ b/src/main/java/com/algangi/mongle/map/application/service/MapQueryService.java
@@ -1,5 +1,6 @@
 package com.algangi.mongle.map.application.service;
 
+import com.algangi.mongle.block.application.service.BlockQueryService;
 import com.algangi.mongle.dynamicCloud.domain.model.DynamicCloud;
 import com.algangi.mongle.dynamicCloud.domain.repository.DynamicCloudRepository;
 import com.algangi.mongle.global.infrastructure.S2CellService;
@@ -9,7 +10,7 @@ import com.algangi.mongle.map.presentation.dto.MapObjectsResponse;
 import com.algangi.mongle.member.domain.Member;
 import com.algangi.mongle.member.service.MemberFinder;
 import com.algangi.mongle.post.domain.model.Post;
-import com.algangi.mongle.post.domain.model.PostStatus; // PostStatus import 추가
+import com.algangi.mongle.post.domain.model.PostStatus;
 import com.algangi.mongle.post.domain.repository.PostQueryRepository;
 import com.algangi.mongle.staticCloud.domain.model.StaticCloud;
 import com.algangi.mongle.staticCloud.repository.StaticCloudRepository;
@@ -34,6 +35,7 @@ public class MapQueryService {
     private final DynamicCloudRepository dynamicCloudRepository;
     private final MemberFinder memberFinder;
     private final S2PolygonConverter s2PolygonConverter;
+    private final BlockQueryService blockQueryService;
 
     public MapObjectsResponse getMapObjects(MapObjectsRequest request) {
         List<String> s2cellTokens = s2CellService.getCellsForRect(
@@ -44,7 +46,10 @@ public class MapQueryService {
             return MapObjectsResponse.empty();
         }
 
-        List<Post> grains = postQueryRepository.findGrainsInCells(s2cellTokens);
+        List<String> blockedAuthorIds = blockQueryService.getBlockedUserIds(request.memberId());
+
+        List<Post> grains = postQueryRepository.findGrainsInCells(s2cellTokens, blockedAuthorIds);
+
         List<StaticCloud> staticClouds = staticCloudRepository.findCloudsInCells(s2cellTokens);
         List<DynamicCloud> dynamicClouds = dynamicCloudRepository.findActiveCloudsInCells(
             s2cellTokens);

--- a/src/main/java/com/algangi/mongle/map/presentation/dto/MapObjectsRequest.java
+++ b/src/main/java/com/algangi/mongle/map/presentation/dto/MapObjectsRequest.java
@@ -6,7 +6,8 @@ public record MapObjectsRequest(
     @NotNull(message = "swLat은 필수값입니다.") Double swLat,
     @NotNull(message = "swLng은 필수값입니다.") Double swLng,
     @NotNull(message = "neLat은 필수값입니다.") Double neLat,
-    @NotNull(message = "neLng은 필수값입니다.") Double neLng
+    @NotNull(message = "neLng은 필수값입니다.") Double neLng,
+    String memberId
 ) {
 
 }

--- a/src/main/java/com/algangi/mongle/map/presentation/dto/MapObjectsResponse.java
+++ b/src/main/java/com/algangi/mongle/map/presentation/dto/MapObjectsResponse.java
@@ -8,14 +8,22 @@ public record MapObjectsResponse(
     List<StaticCloudInfo> staticClouds,
     List<DynamicCloudInfo> dynamicClouds
 ) {
-
+    
     public record Grain(
         String postId,
         double latitude,
         double longitude,
-        String profileImageUrl
+        Author author
     ) {
 
+
+        public record Author(
+            String id,
+            String nickname,
+            String profileImageUrl
+        ) {
+
+        }
     }
 
     public record StaticCloudInfo(
@@ -49,4 +57,3 @@ public record MapObjectsResponse(
             Collections.emptyList());
     }
 }
-

--- a/src/main/java/com/algangi/mongle/post/application/service/PostQueryService.java
+++ b/src/main/java/com/algangi/mongle/post/application/service/PostQueryService.java
@@ -1,6 +1,5 @@
 package com.algangi.mongle.post.application.service;
 
-import com.algangi.mongle.comment.domain.repository.CommentQueryRepository;
 import com.algangi.mongle.global.application.service.ViewUrlIssueService;
 import com.algangi.mongle.global.util.DateTimeUtil;
 import com.algangi.mongle.member.domain.Member;
@@ -9,6 +8,7 @@ import com.algangi.mongle.post.application.dto.IssuedUrlInfo;
 import com.algangi.mongle.post.application.helper.PostFinder;
 import com.algangi.mongle.post.domain.model.Post;
 import com.algangi.mongle.post.domain.model.PostFile;
+import com.algangi.mongle.post.domain.model.PostStatus;
 import com.algangi.mongle.post.domain.repository.PostQueryRepository;
 import com.algangi.mongle.post.event.PostViewedEvent;
 import com.algangi.mongle.post.presentation.dto.PostDetailResponse;
@@ -16,7 +16,9 @@ import com.algangi.mongle.post.presentation.dto.PostListRequest;
 import com.algangi.mongle.post.presentation.dto.PostListResponse;
 import com.algangi.mongle.post.presentation.dto.PostSort;
 import com.algangi.mongle.post.presentation.dto.ViewUrlRequest;
+import com.algangi.mongle.stats.application.dto.PostStats;
 import com.algangi.mongle.stats.application.service.ContentStatsService;
+import com.algangi.mongle.stats.application.service.StatsQueryService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
@@ -36,37 +38,35 @@ public class PostQueryService {
 
     private final PostFinder postFinder;
     private final MemberFinder memberFinder;
-    private final CommentQueryRepository commentQueryRepository;
     private final PostQueryRepository postQueryRepository;
     private final ViewUrlIssueService viewUrlIssueService;
     private final ApplicationEventPublisher eventPublisher;
     private final ContentStatsService contentStatsService;
+    private final StatsQueryService statsQueryService;
 
     public PostListResponse getPostList(PostListRequest request) {
-        // 1. DB에서 다음 페이지 존재 여부 확인을 위해 요청 사이즈보다 1개 더 조회
         List<Post> fetchedPosts = postQueryRepository.findPostsByCondition(request);
         boolean hasNext = fetchedPosts.size() > request.size();
-        // 2. 실제 페이지에 해당하는 데이터만 잘라냄 (가장 중요한 리팩토링 포인트)
         List<Post> postsOnPage = hasNext ? fetchedPosts.subList(0, request.size()) : fetchedPosts;
 
         if (postsOnPage.isEmpty()) {
             return PostListResponse.empty();
         }
 
-        // 3. 잘라낸 'postsOnPage'를 기준으로 후속 작업을 처리하여 불필요한 연산을 방지
-        Map<String, Long> commentCounts = getCommentCounts(postsOnPage);
-        Map<String, Member> authors = getAuthors(postsOnPage);
-        Map<String, String> photoUrls = getFirstPhotoUrls(postsOnPage); // postId -> URL 맵
+        List<String> postIds = postsOnPage.stream().map(Post::getId).toList();
+        Map<String, PostStats> statsMap = statsQueryService.getPostStatsMap(postIds);
 
-        // 4. DTO 조립
+        Map<String, Member> authors = getAuthors(postsOnPage);
+        Map<String, String> photoUrls = getFirstPhotoUrls(postsOnPage);
+
         List<PostListResponse.PostSummary> summaries = postsOnPage.stream().map(post -> {
             Member author = authors.get(post.getAuthorId());
-            long commentCount = commentCounts.getOrDefault(post.getId(), 0L);
             String photoUrl = photoUrls.get(post.getId());
             List<String> photoUrlList =
                 photoUrl != null ? List.of(photoUrl) : Collections.emptyList();
+            PostStats stats = statsMap.getOrDefault(post.getId(), PostStats.empty());
 
-            return PostListResponse.PostSummary.from(post, author, commentCount, photoUrlList);
+            return PostListResponse.PostSummary.from(post, author, photoUrlList, stats);
         }).toList();
 
         String nextCursor = createNextCursor(postsOnPage, hasNext, request.sortBy());
@@ -74,13 +74,24 @@ public class PostQueryService {
         return new PostListResponse(summaries, nextCursor, hasNext);
     }
 
+
     public PostDetailResponse getPostDetail(String postId) {
         Post post = postFinder.getPostOrThrow(postId);
         Member author = memberFinder.getMemberOrThrow(post.getAuthorId());
-        long commentCount = commentQueryRepository.countByPostId(postId);
 
         contentStatsService.incrementPostViewCount(postId);
         eventPublisher.publishEvent(new PostViewedEvent(postId));
+
+        PostStats stats = statsQueryService.getPostStatsMap(List.of(postId))
+            .getOrDefault(postId, PostStats.empty());
+
+        String profileImageUrl =
+            (post.getStatus() == PostStatus.ACTIVE) ? author.getProfileImage() : null;
+        PostDetailResponse.Author authorDto = new PostDetailResponse.Author(
+            author.getMemberId(),
+            author.getNickname(),
+            profileImageUrl
+        );
 
         List<String> photoKeys = post.getPostFiles().stream()
             .map(PostFile::getFileKey)
@@ -94,16 +105,8 @@ public class PostQueryService {
         List<String> photoUrls = issueFileUrls(photoKeys);
         List<String> videoUrls = issueFileUrls(videoKeys);
 
-        return PostDetailResponse.from(post, author, commentCount, photoUrls, videoUrls);
-    }
-
-
-    private Map<String, Long> getCommentCounts(List<Post> posts) {
-        List<String> postIds = posts.stream().map(Post::getId).toList();
-        if (postIds.isEmpty()) {
-            return Collections.emptyMap();
-        }
-        return commentQueryRepository.countCommentsByPostIds(postIds);
+        // from 메서드에 author 대신 authorDto를 전달
+        return PostDetailResponse.from(post, authorDto, stats, photoUrls, videoUrls);
     }
 
     private Map<String, Member> getAuthors(List<Post> posts) {
@@ -116,8 +119,6 @@ public class PostQueryService {
     }
 
     private Map<String, String> getFirstPhotoUrls(List<Post> posts) {
-        // 1. postId를 Key로, 첫 번째 이미지의 fileKey를 Value로 갖는 Map을 생성합니다.
-        // 이미지가 없는 게시글의 경우 Value는 null이 됩니다.
         Map<String, String> postIdToPhotoKeyMap = posts.stream()
             .collect(Collectors.toMap(
                 Post::getId,
@@ -128,7 +129,6 @@ public class PostQueryService {
                     .orElse(null)
             ));
 
-        // 2. 이미지가 있는 게시글의 fileKey 목록만 추출하여 중복을 제거합니다.
         List<String> distinctPhotoKeys = postIdToPhotoKeyMap.values().stream()
             .filter(Objects::nonNull)
             .distinct()
@@ -138,10 +138,8 @@ public class PostQueryService {
             return Collections.emptyMap();
         }
 
-        // 3. 추출된 fileKey 목록으로 Presigned URL을 한 번에 요청합니다.
         Map<String, String> photoKeyToUrlMap = issueFileUrlsToMap(distinctPhotoKeys);
 
-        // 4. 최종적으로 postId를 Key로, Presigned URL을 Value로 갖는 Map을 생성하여 반환합니다.
         return postIdToPhotoKeyMap.entrySet().stream()
             .filter(entry -> entry.getValue() != null)
             .collect(Collectors.toMap(
@@ -149,7 +147,6 @@ public class PostQueryService {
                 entry -> photoKeyToUrlMap.get(entry.getValue())
             ));
     }
-
 
     private List<String> issueFileUrls(List<String> fileKeys) {
         if (fileKeys == null || fileKeys.isEmpty()) {
@@ -186,7 +183,6 @@ public class PostQueryService {
 
         Post lastPost = content.get(content.size() - 1);
         String formattedDate = lastPost.getCreatedDate().format(DateTimeUtil.CURSOR_DATE_FORMATTER);
-
         PostSort finalSort = (sort == null) ? PostSort.ranking_score : sort;
 
         if (finalSort == PostSort.ranking_score) {

--- a/src/main/java/com/algangi/mongle/post/domain/repository/PostQueryRepository.java
+++ b/src/main/java/com/algangi/mongle/post/domain/repository/PostQueryRepository.java
@@ -8,28 +8,11 @@ import java.util.Map;
 
 public interface PostQueryRepository {
 
-    /**
-     * 조건에 맞는 게시글 목록을 커서 기반으로 조회합니다.
-     */
-    List<Post> findPostsByCondition(PostListRequest request);
+    List<Post> findPostsByCondition(PostListRequest request, List<String> blockedAuthorIds);
 
-    /**
-     * 주어진 S2 Cell 목록 내에 '알갱이' 상태로 존재하는 게시글들을 조회합니다.
-     */
-    List<Post> findGrainsInCells(List<String> s2cellTokens);
+    List<Post> findGrainsInCells(List<String> s2cellTokens, List<String> blockedAuthorIds);
 
-    /**
-     * 주어진 정적 구름 ID 목록에 대해 각 구름에 속한 게시글 수를 조회합니다.
-     *
-     * @return Map<CloudId, PostCount>
-     */
     Map<Long, Long> countPostsByStaticCloudIds(List<Long> cloudIds);
 
-    /**
-     * 주어진 동적 구름 ID 목록에 대해 각 구름에 속한 게시글 수를 조회합니다.
-     *
-     * @return Map<CloudId, PostCount>
-     */
     Map<Long, Long> countPostsByDynamicCloudIds(List<Long> cloudIds);
 }
-

--- a/src/main/java/com/algangi/mongle/post/presentation/dto/PostDetailResponse.java
+++ b/src/main/java/com/algangi/mongle/post/presentation/dto/PostDetailResponse.java
@@ -2,6 +2,7 @@ package com.algangi.mongle.post.presentation.dto;
 
 import com.algangi.mongle.member.domain.Member;
 import com.algangi.mongle.post.domain.model.Post;
+import com.algangi.mongle.stats.application.dto.PostStats;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -15,7 +16,8 @@ public record PostDetailResponse(
     List<String> photoUrls,
     List<String> videoUrls,
     LocalDateTime createdAt,
-    long viewCount, // TODO: 조회수 기능 구현 필요
+    LocalDateTime updatedAt,
+    long viewCount,
     long likeCount,
     long dislikeCount,
     long commentCount
@@ -32,29 +34,29 @@ public record PostDetailResponse(
                 return new Author(null, "익명의 몽글러", null);
             }
             return new Author(
-                member.getMemberId().toString(),
+                member.getMemberId(),
                 member.getNickname(),
                 member.getProfileImage()
             );
         }
     }
-
-    public static PostDetailResponse from(Post post, Member author, long commentCount,
+    
+    public static PostDetailResponse from(Post post, Author authorDto, PostStats stats,
         List<String> photoUrls, List<String> videoUrls) {
         return new PostDetailResponse(
             post.getId(),
-            Author.from(author),
+            authorDto,
             post.getContent(),
             post.getLocation().getLatitude(),
             post.getLocation().getLongitude(),
             photoUrls,
             videoUrls,
             post.getCreatedDate(),
-            0, // TODO: 조회수 기능 구현 후 반영
+            post.getUpdatedDate(),
+            stats.viewCount(),
             post.getLikeCount(),
             post.getDislikeCount(),
-            commentCount
+            stats.commentCount()
         );
     }
 }
-

--- a/src/main/java/com/algangi/mongle/post/presentation/dto/PostListRequest.java
+++ b/src/main/java/com/algangi/mongle/post/presentation/dto/PostListRequest.java
@@ -7,7 +7,8 @@ public record PostListRequest(
     String cloudId,
     String cursor,
     Integer size,
-    PostSort sortBy
+    PostSort sortBy,
+    String memberId
 ) {
 
     private static final int DEFAULT_SIZE = 10;
@@ -24,4 +25,3 @@ public record PostListRequest(
         return Math.min(size, MAX_SIZE);
     }
 }
-

--- a/src/main/java/com/algangi/mongle/stats/application/dto/PostStats.java
+++ b/src/main/java/com/algangi/mongle/stats/application/dto/PostStats.java
@@ -1,0 +1,11 @@
+package com.algangi.mongle.stats.application.dto;
+
+public record PostStats(
+    long viewCount,
+    long commentCount
+) {
+
+    public static PostStats empty() {
+        return new PostStats(0L, 0L);
+    }
+}

--- a/src/main/java/com/algangi/mongle/stats/application/service/StatsQueryService.java
+++ b/src/main/java/com/algangi/mongle/stats/application/service/StatsQueryService.java
@@ -1,6 +1,7 @@
 package com.algangi.mongle.stats.application.service;
 
 import com.algangi.mongle.comment.application.vo.CommentStats;
+import com.algangi.mongle.stats.application.dto.PostStats;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
@@ -16,6 +17,9 @@ public class StatsQueryService {
     private static final String LIKE_KEY_FORMAT = "likes::comment::%s";
     private static final String DISLIKE_KEY_FORMAT = "dislikes::comment::%s";
 
+    private static final String VIEW_COUNT_KEY_FORMAT = "views::post::%s";
+    private static final String COMMENT_COUNT_KEY_FORMAT = "comments::post::%s";
+
     public Map<String, CommentStats> getCommentStatsMap(List<String> commentIds) {
         if (commentIds == null || commentIds.isEmpty()) {
             return Collections.emptyMap();
@@ -27,7 +31,7 @@ public class StatsQueryService {
 
         // MGET을 위해 모든 키를 하나의 리스트로 합침
         List<String> results = redisTemplate.opsForValue()
-                .multiGet(concatLists(likeKeys, dislikeKeys));
+            .multiGet(concatLists(likeKeys, dislikeKeys));
 
         if (results == null) {
             results = Collections.emptyList();
@@ -42,11 +46,39 @@ public class StatsQueryService {
         }
         return statsMap;
     }
+    
+    public Map<String, PostStats> getPostStatsMap(List<String> postIds) {
+        if (postIds == null || postIds.isEmpty()) {
+            return Collections.emptyMap();
+        }
+
+        // 각 통계 유형별 키 목록 생성
+        List<String> viewCountKeys = buildKeys(postIds, VIEW_COUNT_KEY_FORMAT);
+        List<String> commentCountKeys = buildKeys(postIds, COMMENT_COUNT_KEY_FORMAT);
+
+        // MGET을 위해 모든 키를 하나의 리스트로 합침
+        List<String> allKeys = concatLists(viewCountKeys, commentCountKeys);
+        List<String> results = redisTemplate.opsForValue().multiGet(allKeys);
+
+        if (results == null) {
+            results = Collections.emptyList();
+        }
+
+        // 결과를 Map<postId, PostStats> 형태로 가공
+        Map<String, PostStats> statsMap = new HashMap<>();
+        for (int i = 0; i < postIds.size(); i++) {
+            String postId = postIds.get(i);
+            long viewCount = safeParseLong(results, i);
+            long commentCount = safeParseLong(results, i + postIds.size());
+            statsMap.put(postId, new PostStats(viewCount, commentCount));
+        }
+        return statsMap;
+    }
 
     private List<String> buildKeys(List<String> ids, String format) {
         return ids.stream()
-                .map(id -> String.format(format, id))
-                .toList();
+            .map(id -> String.format(format, id))
+            .toList();
     }
 
     private List<String> concatLists(List<String> first, List<String> second) {
@@ -57,9 +89,13 @@ public class StatsQueryService {
     }
 
     private long safeParseLong(List<String> results, int index) {
-        if (index >= results.size()) return 0L;
+        if (index >= results.size()) {
+            return 0L;
+        }
         String value = results.get(index);
-        if (value == null) return 0L;
+        if (value == null) {
+            return 0L;
+        }
         try {
             return Long.parseLong(value);
         } catch (NumberFormatException e) {


### PR DESCRIPTION
## 📄Summary
### 조회 API 개선

- 통계 데이터 Redis 연동: 게시글 목록/상세 조회 시, 조회수와 댓글 수를 Redis에서 조회하도록 변경
- 응답 형식 변경:
  - [게시글 목록/상세, 지도 객체] 작성자 정보를 author 객체(id, nickname, profileImageUrl)로 그룹화
  - [게시글 목록/상세] updatedAt 필드 추가
  - [게시글 목록] viewCount 필드 추가
- 차단 사용자 콘텐츠 필터링: 게시글 목록 및 지도 객체 조회 시, 현재 사용자가 차단한 유저의 게시글은 결과에서 제외

<br><br>

## 🙋🏻 More
- 논의하고 싶은 내용 등

<br><br>

## 🔗관련 이슈
- Close #38 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - 지도와 게시글 목록에서 차단한 사용자의 콘텐츠가 더 이상 노출되지 않습니다.
  - 게시글 목록·상세에 조회수와 댓글 수가 실제 통계로 표시됩니다.
  - 게시글에 업데이트 시간(Updated At)이 추가되었습니다.
  - 작성자 정보가 닉네임·프로필 이미지를 포함한 구조로 개선되었고, 비활성 글이거나 작성자가 없을 경우 익명 처리 및 프로필 이미지 미노출로 표시됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->