### PR TITLE
Feature/46 삭제된 댓글은 싹 다 노출되도록 비즈니스 로직 변경

### DIFF
--- a/src/main/java/com/algangi/mongle/comment/application/event/CommentDeletedEvent.java
+++ b/src/main/java/com/algangi/mongle/comment/application/event/CommentDeletedEvent.java
@@ -1,8 +1,0 @@
-package com.algangi.mongle.comment.application.event;
-
-public record CommentDeletedEvent(
-        String postId,
-        String commentId
-) {
-
-}

--- a/src/main/java/com/algangi/mongle/comment/application/event/PostStatsListener.java
+++ b/src/main/java/com/algangi/mongle/comment/application/event/PostStatsListener.java
@@ -20,10 +20,4 @@ public class PostStatsListener {
         contentStatsService.addCommentToRanking(event.postId(), event.commentId());
     }
 
-    @Async("statsUpdateTaskExecutor")
-    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
-    public void handleCommentDeletion(CommentDeletedEvent event) {
-        contentStatsService.decrementPostCommentCount(event.postId());
-        contentStatsService.removeCommentFromRanking(event.postId(), event.commentId());
-    }
 }

--- a/src/main/java/com/algangi/mongle/comment/application/service/CommentCommandService.java
+++ b/src/main/java/com/algangi/mongle/comment/application/service/CommentCommandService.java
@@ -1,7 +1,6 @@
 package com.algangi.mongle.comment.application.service;
 
 import com.algangi.mongle.comment.application.event.CommentCreatedEvent;
-import com.algangi.mongle.comment.application.event.CommentDeletedEvent;
 import com.algangi.mongle.stats.application.service.ContentStatsService;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
@@ -55,13 +54,8 @@ public class CommentCommandService {
     @Transactional
     public void deleteComment(String commentId) {
         Comment comment = commentFinder.getCommentOrThrow(commentId);
-
-        boolean wasAlreadyDeleted = comment.isDeleted();
         commentDomainService.deleteComment(comment);
 
-        if (!wasAlreadyDeleted) {
-            eventPublisher.publishEvent(new CommentDeletedEvent(comment.getPost().getId(), comment.getId()));
-        }
     }
 
 }

--- a/src/main/java/com/algangi/mongle/comment/domain/repository/CommentQueryRepository.java
+++ b/src/main/java/com/algangi/mongle/comment/domain/repository/CommentQueryRepository.java
@@ -16,7 +16,4 @@ public interface CommentQueryRepository {
 
     Map<String, Boolean> findHasRepliesByParentIds(List<String> parentIds);
 
-    long countByPostId(String postId);
-
-    Map<String, Long> countCommentsByPostIds(List<String> postIds);
 }

--- a/src/main/java/com/algangi/mongle/comment/infrastructure/persistence/CommentQueryDslRepository.java
+++ b/src/main/java/com/algangi/mongle/comment/infrastructure/persistence/CommentQueryDslRepository.java
@@ -91,28 +91,4 @@ public class CommentQueryDslRepository implements CommentQueryRepository {
                 ));
     }
 
-    @Override
-    public long countByPostId(String postId) {
-        if (postId == null) {
-            return 0L;
-        }
-        Long count = queryFactory
-                .select(comment.count())
-                .from(comment)
-                .where(comment.post.id.eq(postId), comment.deletedAt.isNull())
-                .fetchOne();
-        return count != null ? count : 0L;
-    }
-
-    @Override
-    public Map<String, Long> countCommentsByPostIds(List<String> postIds) {
-        if (postIds == null || postIds.isEmpty()) {
-            return Collections.emptyMap();
-        }
-        return queryFactory
-                .from(comment)
-                .where(comment.post.id.in(postIds), comment.deletedAt.isNull())
-                .groupBy(comment.post.id)
-                .transform(GroupBy.groupBy(comment.post.id).as(comment.count()));
-    }
 }

--- a/src/main/java/com/algangi/mongle/comment/infrastructure/persistence/CommentQueryDslRepository.java
+++ b/src/main/java/com/algangi/mongle/comment/infrastructure/persistence/CommentQueryDslRepository.java
@@ -40,7 +40,6 @@ public class CommentQueryDslRepository implements CommentQueryRepository {
                         filterFactory.eqPostId(condition.postId()),
                         filterFactory.isParentComment(),
                         filterFactory.cursorCondition(condition.cursor(), condition.sort()),
-                        filterFactory.visibleCommentCondition(),
                         filterFactory.notInBlockedMemberIds(blockedMemberIds)
                 )
                 .orderBy(orderFactory.createOrderSpecifiers(condition.sort()))
@@ -58,7 +57,6 @@ public class CommentQueryDslRepository implements CommentQueryRepository {
                 .leftJoin(comment.member).fetchJoin()
                 .where(
                         filterFactory.eqParentId(condition.parentId()),
-                        comment.deletedAt.isNull(),
                         filterFactory.cursorCondition(condition.cursor(), condition.sort()),
                         filterFactory.notInBlockedMemberIds(blockedMemberIds)
                 )
@@ -80,8 +78,7 @@ public class CommentQueryDslRepository implements CommentQueryRepository {
                 .select(reply.parentComment.id)
                 .from(reply)
                 .where(
-                        reply.parentComment.id.in(parentIds),
-                        reply.deletedAt.isNull()
+                        reply.parentComment.id.in(parentIds)
                 )
                 .groupBy(reply.parentComment.id)
                 .fetch();

--- a/src/main/java/com/algangi/mongle/global/presentation/controller/FileViewUrlIssueController.java
+++ b/src/main/java/com/algangi/mongle/global/presentation/controller/FileViewUrlIssueController.java
@@ -14,7 +14,7 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 
 @RestController
-@RequestMapping("/api/files/view-urls")
+@RequestMapping("/api/v1/files/view-urls")
 @RequiredArgsConstructor
 public class FileViewUrlIssueController {
 

--- a/src/main/java/com/algangi/mongle/map/presentation/controller/MapController.java
+++ b/src/main/java/com/algangi/mongle/map/presentation/controller/MapController.java
@@ -13,7 +13,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
-@RequestMapping("/api/map")
+@RequestMapping("/api/v1/map")
 @RequiredArgsConstructor
 public class MapController {
 

--- a/src/main/java/com/algangi/mongle/post/presentation/controller/PostController.java
+++ b/src/main/java/com/algangi/mongle/post/presentation/controller/PostController.java
@@ -20,7 +20,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
-@RequestMapping("/api")
+@RequestMapping("/api/v1")
 @RequiredArgsConstructor
 public class PostController {
 

--- a/src/main/java/com/algangi/mongle/post/presentation/controller/PostFileUploadUrlIssueController.java
+++ b/src/main/java/com/algangi/mongle/post/presentation/controller/PostFileUploadUrlIssueController.java
@@ -14,7 +14,7 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 
 @RestController
-@RequestMapping("/api/post-files/upload-urls")
+@RequestMapping("/api/v1/post-files/upload-urls")
 @RequiredArgsConstructor
 public class PostFileUploadUrlIssueController {
 

--- a/src/main/java/com/algangi/mongle/reaction/presentation/controller/ReactionController.java
+++ b/src/main/java/com/algangi/mongle/reaction/presentation/controller/ReactionController.java
@@ -9,7 +9,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
-@RequestMapping("/api")
+@RequestMapping("/api/v1")
 @RequiredArgsConstructor
 public class ReactionController {
 

--- a/src/main/java/com/algangi/mongle/report/presentation/controller/AdminReportController.java
+++ b/src/main/java/com/algangi/mongle/report/presentation/controller/AdminReportController.java
@@ -13,7 +13,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
-@RequestMapping("/api/admin/reports")
+@RequestMapping("/api/v1/admin/reports")
 @RequiredArgsConstructor
 public class AdminReportController {
 

--- a/src/main/java/com/algangi/mongle/report/presentation/controller/ReportController.java
+++ b/src/main/java/com/algangi/mongle/report/presentation/controller/ReportController.java
@@ -9,7 +9,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
-@RequestMapping("/api/reports")
+@RequestMapping("/api/v1/reports")
 @RequiredArgsConstructor
 public class ReportController {
 

--- a/src/main/java/com/algangi/mongle/stats/application/service/ContentStatsService.java
+++ b/src/main/java/com/algangi/mongle/stats/application/service/ContentStatsService.java
@@ -47,16 +47,6 @@ public class ContentStatsService {
         redisTemplate.opsForZSet().add(key, commentId, 0);
     }
 
-    public void removeCommentFromRanking(String postId, String commentId) {
-        String key = COMMENT_RANKING_KEY_FORMAT + postId;
-        redisTemplate.opsForZSet().remove(key, commentId);
-    }
-
-    public void decrementPostCommentCount(String postId) {
-        String key = getKey(COMMENT_COUNT_KEY_PREFIX, TargetType.POST, postId);
-        redisTemplate.execute(decrementScript, List.of(key));
-    }
-
     public ReactionResponse updateReaction(TargetType targetType, String targetId, String memberId, ReactionType reactionType, String postId) {
         // 1. 리액션 타입 검증
         validateReactionType(reactionType);


### PR DESCRIPTION
## 📄Summary
- 삭제된 댓글은 싹 다 노출되도록 비즈니스 로직 변경
- 필요없는 메서드 삭제
- 엔ㅌ드포인트 v1으로 통일

<br><br>

## 🔗관련 이슈
- Close #46 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - 주요 REST API 기본 경로를 /api → /api/v1로 일괄 변경(파일 보기 URL, 지도, 게시글, 반응, 신고, 관리자 신고, 게시글 파일 업로드 등). 기존 클라이언트는 호출 경로를 /api/v1/*로 업데이트 필요.

- Chores
  - 댓글 삭제 관련 통계·이벤트 처리 로직을 정리하여 불필요한 동작을 제거.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->