### PR TITLE
Feat/63 조회 관련 이슈 해결

### DIFF
--- a/src/main/java/com/algangi/mongle/dynamicCloud/domain/repository/DynamicCloudRepository.java
+++ b/src/main/java/com/algangi/mongle/dynamicCloud/domain/repository/DynamicCloudRepository.java
@@ -7,7 +7,6 @@ import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 import java.util.Optional;
-import java.util.Set;
 
 public interface DynamicCloudRepository extends JpaRepository<DynamicCloud, Long> {
 
@@ -16,9 +15,8 @@ public interface DynamicCloudRepository extends JpaRepository<DynamicCloud, Long
     Optional<DynamicCloud> findActiveByS2TokenId(@Param("s2TokenId") String s2TokenId);
 
     // 주어진 S2 Cell 목록과 겹치는 활성화된 동적 구름들을 조회
-    @Query("select DISTINCT dc from DynamicCloud dc join dc.s2TokenIds s2TokenId " +
-        "where s2TokenId in :s2cellTokens and dc.status = 'ACTIVE'")
+    @Query("SELECT DISTINCT dc FROM DynamicCloud dc JOIN FETCH dc.s2TokenIds WHERE dc.id IN " +
+        "(SELECT d.id FROM DynamicCloud d JOIN d.s2TokenIds s2_token WHERE s2_token IN :s2cellTokens AND d.status = 'ACTIVE')")
     List<DynamicCloud> findActiveCloudsInCells(@Param("s2cellTokens") List<String> s2cellTokens);
 
 }
-

--- a/src/main/java/com/algangi/mongle/global/infrastructure/S3ViewUrlIssueService.java
+++ b/src/main/java/com/algangi/mongle/global/infrastructure/S3ViewUrlIssueService.java
@@ -71,7 +71,7 @@ public class S3ViewUrlIssueService implements ViewUrlIssueService {
                 .build();
 
             String issuedUrl = cloudFrontUtilities.getSignedUrlWithCannedPolicy(signerRequest)
-                .toString();
+                .url();
             LocalDateTime expiresAt = LocalDateTime.now()
                 .plusMinutes(cloudFrontProperties.expirationMinutes());
             return new IssuedUrlInfo(fileKey, issuedUrl, expiresAt);

--- a/src/main/java/com/algangi/mongle/post/exception/PostErrorCode.java
+++ b/src/main/java/com/algangi/mongle/post/exception/PostErrorCode.java
@@ -11,7 +11,8 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum PostErrorCode implements ErrorCode {
 
-    POST_NOT_FOUND(HttpStatus.NOT_FOUND, "POST-001", "게시글이 존재하지 않습니다.");
+    POST_NOT_FOUND(HttpStatus.NOT_FOUND, "POST-001", "게시글이 존재하지 않습니다."),
+    CLOUD_NOT_FOUND(HttpStatus.NOT_FOUND, "POST-002", "요청한 구름이 존재하지 않습니다.");
 
     private final HttpStatus status;
     private final String code;

--- a/src/main/java/com/algangi/mongle/staticCloud/repository/StaticCloudRepository.java
+++ b/src/main/java/com/algangi/mongle/staticCloud/repository/StaticCloudRepository.java
@@ -1,7 +1,6 @@
 package com.algangi.mongle.staticCloud.repository;
 
 import com.algangi.mongle.staticCloud.domain.model.StaticCloud;
-import java.util.Set;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -17,6 +16,7 @@ public interface StaticCloudRepository extends JpaRepository<StaticCloud, Long> 
     Optional<StaticCloud> findByS2TokenId(@Param("s2TokenId") String s2TokenId);
 
     // 주어진 S2 Cell 목록과 겹치는 정적 구름들을 조회
-    @Query("select distinct sc from StaticCloud sc join sc.s2TokenIds s2TokenId where s2TokenId in :s2cellTokens")
+    @Query("SELECT DISTINCT sc FROM StaticCloud sc JOIN FETCH sc.s2TokenIds WHERE sc.id IN " +
+        "(SELECT s.id FROM StaticCloud s JOIN s.s2TokenIds s2_token WHERE s2_token IN :s2cellTokens)")
     List<StaticCloud> findCloudsInCells(@Param("s2cellTokens") List<String> s2cellTokens);
 }


### PR DESCRIPTION
## 📄Summary
지도 및 게시글 조회 관련 API에서 발생한 여러 버그를 수정하고 기능을 개선했습니다.

- 이미지 URL 형식 오류 수정: CloudFront Pre-signed URL 생성 시 DefaultSignedUrl(url=...) 래퍼 문자열이 포함되던 문제를 해결하고 순수한 URL만 반환하도록 수정했습니다.
- 동적/정적 구름 폴리곤 조회 오류 수정: 지도 조회 시 S2 Cell ID 목록이 지연 로딩(Lazy Loading)되어 구름의 폴리곤 정보가 누락되던 문제를 해결했습니다. 이제 게시글 3개 이상 작성 시 생성된 동적 구름도 정상적으로 지도에 표시됩니다.
- cloudId 기반 게시글 조회 500 에러 해결: cloudId로 게시글 목록 조회 시, 게시글의 파일 정보(postFiles)가 지연 로딩되어 발생하던 500 에러를 FETCH JOIN을 통해 해결했습니다.
- 게시글 목록 이미지 전체 반환 기능 추가: 게시글 목록 API에서 각 게시글의 대표 이미지 하나만 반환하던 로직을 수정하여, 게시글에 포함된 모든 이미지 URL 리스트를 반환하도록 개선했습니다.
- 존재하지 않는 구름 ID 조회 예외 처리 추가: 존재하지 않는 cloudId나 placeId로 조회 시 500 에러 대신, "요청한 구름이 존재하지 않습니다."라는 메시지와 함께 404 에러를 반환하도록 API 안정성을 강화했습니다.

<br><br>

## 🙋🏻 More
- 논의하고 싶은 내용 등

<br><br>

## 🔗관련 이슈
- Close #63 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - 게시글 목록에서 각 게시글의 대표 이미지 1개 대신 여러 사진 URL을 제공.
  - 존재하지 않는 구름 요청 시 명확한 404 오류 응답을 반환.
- Bug Fixes
  - 이미지 보기용 서명 URL 생성의 안정성과 호환성 개선.
  - 구름 조회 시 셀 기반 필터링의 정확도 향상 및 중복 감소로 결과 신뢰성 개선.
  - 목록 응답 구성 로직을 정비하여 일관성과 체감 성능을 개선.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->