### PR TITLE
Feat/47 게시글 삭제 api 구현

### DIFF
--- a/src/main/java/com/algangi/mongle/post/application/service/PostCommandService.java
+++ b/src/main/java/com/algangi/mongle/post/application/service/PostCommandService.java
@@ -1,0 +1,29 @@
+package com.algangi.mongle.post.application.service;
+
+import com.algangi.mongle.global.exception.ApplicationException;
+import com.algangi.mongle.post.application.helper.PostFinder;
+import com.algangi.mongle.post.domain.model.Post;
+import com.algangi.mongle.post.exception.PostErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Objects;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class PostCommandService {
+
+    private final PostFinder postFinder;
+
+    public void deletePost(String postId, String memberId) {
+        Post post = postFinder.getPostOrThrow(postId);
+        
+        if (!Objects.equals(post.getAuthorId(), memberId)) {
+            throw new ApplicationException(PostErrorCode.POST_ACCESS_DENIED);
+        }
+
+        post.softDeleteByUser();
+    }
+}

--- a/src/main/java/com/algangi/mongle/post/application/service/PostQueryService.java
+++ b/src/main/java/com/algangi/mongle/post/application/service/PostQueryService.java
@@ -3,6 +3,7 @@ package com.algangi.mongle.post.application.service;
 import com.algangi.mongle.block.application.service.BlockQueryService;
 import com.algangi.mongle.dynamicCloud.domain.repository.DynamicCloudRepository;
 import com.algangi.mongle.global.application.service.ViewUrlIssueService;
+import com.algangi.mongle.global.exception.ApplicationException;
 import com.algangi.mongle.global.util.DateTimeUtil;
 import com.algangi.mongle.member.domain.Member;
 import com.algangi.mongle.member.service.MemberFinder;
@@ -14,8 +15,11 @@ import com.algangi.mongle.post.domain.model.PostStatus;
 import com.algangi.mongle.post.domain.repository.PostQueryRepository;
 import com.algangi.mongle.post.event.PostViewedEvent;
 import com.algangi.mongle.post.exception.PostErrorCode;
-import com.algangi.mongle.post.presentation.dto.*;
-import com.algangi.mongle.global.exception.ApplicationException;
+import com.algangi.mongle.post.presentation.dto.PostDetailResponse;
+import com.algangi.mongle.post.presentation.dto.PostListRequest;
+import com.algangi.mongle.post.presentation.dto.PostListResponse;
+import com.algangi.mongle.post.presentation.dto.PostSort;
+import com.algangi.mongle.post.presentation.dto.ViewUrlRequest;
 import com.algangi.mongle.staticCloud.repository.StaticCloudRepository;
 import com.algangi.mongle.stats.application.dto.PostStats;
 import com.algangi.mongle.stats.application.service.ContentStatsService;
@@ -26,7 +30,11 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.StringUtils;
 
-import java.util.*;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
@@ -82,6 +90,12 @@ public class PostQueryService {
 
     public PostDetailResponse getPostDetail(String postId) {
         Post post = postFinder.getPostOrThrow(postId);
+
+        if (post.getStatus() == PostStatus.DELETED_BY_USER
+            || post.getStatus() == PostStatus.DELETED_BY_ADMIN) {
+            return PostDetailResponse.deleted();
+        }
+
         Member author = memberFinder.getMemberOrThrow(post.getAuthorId());
 
         contentStatsService.incrementPostViewCount(postId);

--- a/src/main/java/com/algangi/mongle/post/domain/model/Post.java
+++ b/src/main/java/com/algangi/mongle/post/domain/model/Post.java
@@ -174,14 +174,27 @@ public class Post extends TimeBaseEntity {
         this.status = PostStatus.ACTIVE;
     }
 
+    public void softDeleteByUser() {
+        if (this.status == PostStatus.DELETED_BY_USER
+            || this.status == PostStatus.DELETED_BY_ADMIN) {
+            return;
+        }
+        this.status = PostStatus.DELETED_BY_USER;
+    }
+
+
     public void increaseLikeCount(long delta) {
         this.likeCount += delta;
-        if (this.likeCount < 0) this.likeCount = 0;
+        if (this.likeCount < 0) {
+            this.likeCount = 0;
+        }
     }
 
     public void increaseDislikeCount(long delta) {
         this.dislikeCount += delta;
-        if (this.dislikeCount < 0) this.dislikeCount = 0;
+        if (this.dislikeCount < 0) {
+            this.dislikeCount = 0;
+        }
     }
 
 }

--- a/src/main/java/com/algangi/mongle/post/exception/PostErrorCode.java
+++ b/src/main/java/com/algangi/mongle/post/exception/PostErrorCode.java
@@ -12,7 +12,8 @@ import lombok.RequiredArgsConstructor;
 public enum PostErrorCode implements ErrorCode {
 
     POST_NOT_FOUND(HttpStatus.NOT_FOUND, "POST-001", "게시글이 존재하지 않습니다."),
-    CLOUD_NOT_FOUND(HttpStatus.NOT_FOUND, "POST-002", "요청한 구름이 존재하지 않습니다.");
+    CLOUD_NOT_FOUND(HttpStatus.NOT_FOUND, "POST-002", "요청한 구름이 존재하지 않습니다."),
+    POST_ACCESS_DENIED(HttpStatus.FORBIDDEN, "POST-003", "게시글에 대한 권한이 없습니다.");
 
     private final HttpStatus status;
     private final String code;

--- a/src/main/java/com/algangi/mongle/post/infrastructure/persistence/PostQueryDslRepository.java
+++ b/src/main/java/com/algangi/mongle/post/infrastructure/persistence/PostQueryDslRepository.java
@@ -2,6 +2,7 @@ package com.algangi.mongle.post.infrastructure.persistence;
 
 import com.algangi.mongle.global.util.ParsingUtil;
 import com.algangi.mongle.post.domain.model.Post;
+import com.algangi.mongle.post.domain.model.PostStatus;
 import com.algangi.mongle.post.domain.repository.PostQueryRepository;
 import com.algangi.mongle.post.presentation.dto.PostListRequest;
 import com.algangi.mongle.post.presentation.dto.PostSort;
@@ -31,6 +32,7 @@ public class PostQueryDslRepository implements PostQueryRepository {
         JPAQuery<Post> query = queryFactory
             .selectFrom(post)
             .where(
+                post.status.eq(PostStatus.ACTIVE),
                 eqPlaceId(request.placeId()),
                 eqCloudId(request.cloudId()),
                 cursorCondition(request.cursor(), request.sortBy()),
@@ -47,6 +49,7 @@ public class PostQueryDslRepository implements PostQueryRepository {
         return queryFactory
             .selectFrom(post)
             .where(
+                post.status.eq(PostStatus.ACTIVE),
                 post.s2TokenId.in(s2cellTokens),
                 post.staticCloudId.isNull(),
                 post.dynamicCloudId.isNull(),

--- a/src/main/java/com/algangi/mongle/post/presentation/controller/PostController.java
+++ b/src/main/java/com/algangi/mongle/post/presentation/controller/PostController.java
@@ -1,6 +1,7 @@
 package com.algangi.mongle.post.presentation.controller;
 
 import com.algangi.mongle.global.dto.ApiResponse;
+import com.algangi.mongle.post.application.service.PostCommandService;
 import com.algangi.mongle.post.application.service.PostCreationService;
 import com.algangi.mongle.post.application.service.PostQueryService;
 import com.algangi.mongle.post.presentation.dto.PostCreateRequest;
@@ -11,12 +12,14 @@ import com.algangi.mongle.post.presentation.dto.PostResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -26,6 +29,7 @@ public class PostController {
 
     private final PostCreationService postCreationService;
     private final PostQueryService postQueryService;
+    private final PostCommandService postCommandService;
 
     // 게시글 생성
     @PostMapping("/posts")
@@ -49,6 +53,16 @@ public class PostController {
         @PathVariable String postId) {
         PostDetailResponse response = postQueryService.getPostDetail(postId);
         return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    // 게시글 삭제
+    @DeleteMapping("/posts/{postId}")
+    public ResponseEntity<ApiResponse<Void>> deletePost(
+        @PathVariable String postId,
+        @RequestParam String memberId // TODO: 인증 기능 도입 후 @AuthenticationPrincipal로 대체 예정
+    ) {
+        postCommandService.deletePost(postId, memberId);
+        return ResponseEntity.ok(ApiResponse.success());
     }
 }
 

--- a/src/main/java/com/algangi/mongle/post/presentation/controller/PostController.java
+++ b/src/main/java/com/algangi/mongle/post/presentation/controller/PostController.java
@@ -59,7 +59,7 @@ public class PostController {
     @DeleteMapping("/posts/{postId}")
     public ResponseEntity<ApiResponse<Void>> deletePost(
         @PathVariable String postId,
-        @RequestParam String memberId // TODO: 인증 기능 도입 시 수정 필요
+        @RequestParam String memberId // TODO: 토큰으로 인증하도록 변경
     ) {
         postCommandService.deletePost(postId, memberId);
         return ResponseEntity.ok(ApiResponse.success());

--- a/src/main/java/com/algangi/mongle/post/presentation/controller/PostController.java
+++ b/src/main/java/com/algangi/mongle/post/presentation/controller/PostController.java
@@ -59,7 +59,7 @@ public class PostController {
     @DeleteMapping("/posts/{postId}")
     public ResponseEntity<ApiResponse<Void>> deletePost(
         @PathVariable String postId,
-        @RequestParam String memberId // TODO: 인증 기능 도입 후 @AuthenticationPrincipal로 대체 예정
+        @RequestParam String memberId // TODO: 인증 기능 도입 시 수정 필요
     ) {
         postCommandService.deletePost(postId, memberId);
         return ResponseEntity.ok(ApiResponse.success());

--- a/src/main/java/com/algangi/mongle/post/presentation/dto/PostDetailResponse.java
+++ b/src/main/java/com/algangi/mongle/post/presentation/dto/PostDetailResponse.java
@@ -5,6 +5,7 @@ import com.algangi.mongle.post.domain.model.Post;
 import com.algangi.mongle.stats.application.dto.PostStats;
 
 import java.time.LocalDateTime;
+import java.util.Collections;
 import java.util.List;
 
 public record PostDetailResponse(
@@ -40,7 +41,7 @@ public record PostDetailResponse(
             );
         }
     }
-    
+
     public static PostDetailResponse from(Post post, Author authorDto, PostStats stats,
         List<String> photoUrls, List<String> videoUrls) {
         return new PostDetailResponse(
@@ -57,6 +58,24 @@ public record PostDetailResponse(
             post.getLikeCount(),
             post.getDislikeCount(),
             stats.commentCount()
+        );
+    }
+
+    public static PostDetailResponse deleted() {
+        return new PostDetailResponse(
+            null,
+            new Author(null, "알 수 없음", null),
+            "삭제된 게시물입니다.",
+            0.0,
+            0.0,
+            Collections.emptyList(),
+            Collections.emptyList(),
+            null,
+            null,
+            0,
+            0,
+            0,
+            0
         );
     }
 }


### PR DESCRIPTION
## 📄Summary

- 데이터를 영구적으로 삭제하는 대신, 게시글의 상태(status)를 DELETED_BY_USER로 변경하는 소프트 삭제(Soft Delete) 방식을 적용했습니다.
- 게시글 삭제를 위한 DELETE /api/v1/posts/{postId} API 엔드포인트를 추가했습니다.
- 삭제 요청 시, 게시글 작성자 본인인지 확인하는 권한 검증 로직을 추가하여 다른 사용자의 게시글을 삭제할 수 없도록 처리했습니다. (현재는 memberId를 requestParam으로 받는데 추후 다같이 jwt를 이용하도록 변경해야 함)
- 삭제된 게시글은 목록(지도 위 알갱이, 구름 내부 등)에서 더 이상 조회되지 않습니다 .
- 삭제된 게시글의 상세 페이지에 직접 접근할 경우, '삭제된 게시물입니다'라는 메시지와 함께 내용이 가려진 상태로 표시됩니다.

<br><br>

## 🙋🏻 More
- 논의하고 싶은 내용 등

<br><br>

## 🔗관련 이슈
- Close #47 
