### PR TITLE
 refactor: 댓글 삭제 시 댓글 수 줄어들도록 리팩토링

### DIFF
--- a/src/main/java/com/algangi/mongle/comment/application/event/CommentDeletedEvent.java
+++ b/src/main/java/com/algangi/mongle/comment/application/event/CommentDeletedEvent.java
@@ -1,0 +1,7 @@
+package com.algangi.mongle.comment.application.event;
+
+public record CommentDeletedEvent(
+        String postId
+) {
+
+}

--- a/src/main/java/com/algangi/mongle/comment/application/event/PostStatsListener.java
+++ b/src/main/java/com/algangi/mongle/comment/application/event/PostStatsListener.java
@@ -20,4 +20,10 @@ public class PostStatsListener {
         contentStatsService.addCommentToRanking(event.postId(), event.commentId());
     }
 
+    @Async("statsUpdateTaskExecutor")
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void handleCommentDeletion(CommentDeletedEvent event) {
+        contentStatsService.decrementPostCommentCount(event.postId());
+    }
+
 }

--- a/src/main/java/com/algangi/mongle/comment/application/service/CommentCommandService.java
+++ b/src/main/java/com/algangi/mongle/comment/application/service/CommentCommandService.java
@@ -1,6 +1,7 @@
 package com.algangi.mongle.comment.application.service;
 
 import com.algangi.mongle.comment.application.event.CommentCreatedEvent;
+import com.algangi.mongle.comment.application.event.CommentDeletedEvent;
 import com.algangi.mongle.global.exception.ApplicationException;
 import com.algangi.mongle.member.domain.MemberStatus;
 import com.algangi.mongle.member.exception.MemberErrorCode;
@@ -64,6 +65,11 @@ public class CommentCommandService {
     @Transactional
     public void deleteComment(String commentId) {
         Comment comment = commentFinder.getCommentOrThrow(commentId);
+        boolean wasAlreadyDeleted = comment.isDeleted();
         commentDomainService.deleteComment(comment);
+
+        if (!wasAlreadyDeleted) {
+            eventPublisher.publishEvent(new CommentDeletedEvent(comment.getPost().getId()));
+        }
     }
 }

--- a/src/main/java/com/algangi/mongle/stats/application/service/ContentStatsService.java
+++ b/src/main/java/com/algangi/mongle/stats/application/service/ContentStatsService.java
@@ -19,6 +19,7 @@ public class ContentStatsService {
 
     private final RedisTemplate<String, String> redisTemplate;
     private final RedisScript<List> reactionScript;
+    private final RedisScript<Long> decrementScript;
 
     private static final String VIEW_COUNT_KEY_PREFIX = "views::";
     private static final String COMMENT_COUNT_KEY_PREFIX = "comments::";
@@ -39,6 +40,11 @@ public class ContentStatsService {
     public void incrementPostCommentCount(String postId) {
         String key = getKey(COMMENT_COUNT_KEY_PREFIX, TargetType.POST, postId);
         redisTemplate.opsForValue().increment(key);
+    }
+
+    public void decrementPostCommentCount(String postId) {
+        String key = COMMENT_COUNT_KEY_PREFIX + "post::" + postId;
+        redisTemplate.execute(decrementScript, List.of(key));
     }
 
     public void addCommentToRanking(String postId, String commentId) {


### PR DESCRIPTION
## 📄Summary
- 댓글 삭제 시 댓글 수 줄어들도록 리팩토링

<br><br>

## 🔗관련 이슈
- Close #93 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신기능
  - 댓글 삭제 시 게시물의 댓글 수가 비동기적으로 자동 반영되어 화면에 최신 수치가 표시됩니다.
- 버그 수정
  - 이미 삭제된 댓글에 대해 중복으로 삭제 처리될 때 댓글 수가 잘못 감소하던 문제를 방지했습니다.
  - 댓글 삭제 후 댓글 수 집계가 누락되거나 지연 표시되던 사례를 개선하여 일관된 수치를 제공합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->