### PR TITLE
Feature/95 댓글 API에서 memberId 파라미터 제거 및 인증 사용자 기반으로 변경 및 댓글 삭제 권한 검증 로직 추가

### DIFF
--- a/src/main/java/com/algangi/mongle/comment/application/service/CommentCommandService.java
+++ b/src/main/java/com/algangi/mongle/comment/application/service/CommentCommandService.java
@@ -5,7 +5,6 @@ import com.algangi.mongle.comment.application.event.CommentDeletedEvent;
 import com.algangi.mongle.global.exception.ApplicationException;
 import com.algangi.mongle.member.domain.MemberStatus;
 import com.algangi.mongle.member.exception.MemberErrorCode;
-import com.algangi.mongle.stats.application.service.ContentStatsService;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -30,7 +29,6 @@ public class CommentCommandService {
     private final CommentFinder commentFinder;
     private final CommentDomainService commentDomainService;
     private final CommentRepository commentRepository;
-    private final ContentStatsService contentStatsService;
     private final ApplicationEventPublisher eventPublisher;
 
     @Transactional
@@ -63,7 +61,7 @@ public class CommentCommandService {
     }
 
     @Transactional
-    public void deleteComment(String commentId) {
+    public void deleteComment(String commentId, String memberId) {
         Comment comment = commentFinder.getCommentOrThrow(commentId);
         boolean wasAlreadyDeleted = comment.isDeleted();
         commentDomainService.deleteComment(comment);

--- a/src/main/java/com/algangi/mongle/comment/presentation/dto/CommentQueryRequest.java
+++ b/src/main/java/com/algangi/mongle/comment/presentation/dto/CommentQueryRequest.java
@@ -5,8 +5,7 @@ import com.algangi.mongle.comment.domain.model.CommentSort;
 public record CommentQueryRequest(
         String cursor,
         Integer size,
-        CommentSort sort,
-        String memberId
+        CommentSort sort
 ) {
 
     private static final int DEFAULT_SIZE = 10;


### PR DESCRIPTION
## 📄Summary
- 댓글 API에서 memberId 파라미터 제거 및 인증 사용자 기반으로 변경 및 댓글 삭제 권한 검증 로직 추가

## 🔗관련 이슈
- Close #95 
