### PR TITLE
refactor: memberId 쿼리 파라미터에 인증 사용자 기반으로 변경

### DIFF
--- a/src/main/java/com/algangi/mongle/block/presentation/controller/BlockController.java
+++ b/src/main/java/com/algangi/mongle/block/presentation/controller/BlockController.java
@@ -1,10 +1,12 @@
 package com.algangi.mongle.block.presentation.controller;
 
+import com.algangi.mongle.auth.infrastructure.security.authentication.CustomUserDetails;
 import com.algangi.mongle.block.application.service.BlockCommandService;
 import com.algangi.mongle.block.application.service.BlockQueryService;
 import com.algangi.mongle.global.dto.ApiResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -20,27 +22,27 @@ public class BlockController {
 
     @GetMapping("/me")
     public ResponseEntity<ApiResponse<List<String>>> getMyBlockedUsers(
-            @RequestParam String memberId
+            @AuthenticationPrincipal CustomUserDetails user
     ) {
-        List<String> blockedUserIds = blockQueryService.getBlockedUserIds(memberId);
+        List<String> blockedUserIds = blockQueryService.getBlockedUserIds(user.userId());
         return ResponseEntity.ok(ApiResponse.success(blockedUserIds));
     }
 
     @PostMapping("/{blockedUserId}")
     public ResponseEntity<ApiResponse<Void>> blockUser(
             @PathVariable String blockedUserId,
-            @RequestParam String memberId
+            @AuthenticationPrincipal CustomUserDetails user
     ) {
-        blockCommandService.blockUser(memberId, blockedUserId);
+        blockCommandService.blockUser(user.userId(), blockedUserId);
         return ResponseEntity.ok(ApiResponse.success());
     }
 
     @DeleteMapping("/{blockedUserId}")
     public ResponseEntity<ApiResponse<Void>> unblockUser(
             @PathVariable String blockedUserId,
-            @RequestParam String memberId
+            @AuthenticationPrincipal CustomUserDetails user
     ) {
-        blockCommandService.unblockUser(memberId, blockedUserId);
+        blockCommandService.unblockUser(user.userId(), blockedUserId);
         return ResponseEntity.ok(ApiResponse.success());
     }
 }

--- a/src/main/java/com/algangi/mongle/comment/presentation/controller/CommentController.java
+++ b/src/main/java/com/algangi/mongle/comment/presentation/controller/CommentController.java
@@ -64,8 +64,7 @@ public class CommentController {
             @PathVariable(name = "postId") String postId,
             @Valid @RequestBody CommentCreateRequest dto,
             @AuthenticationPrincipal CustomUserDetails user)  {
-        String memberId = (user != null) ? user.userId() : null;
-        commentCommandService.createParentComment(postId, dto.content(), memberId);
+        commentCommandService.createParentComment(postId, dto.content(), user.userId());
         return ResponseEntity.ok(ApiResponse.success());
     }
 
@@ -74,8 +73,7 @@ public class CommentController {
             @PathVariable(name = "parentCommentId") String parentCommentId,
             @Valid @RequestBody CommentCreateRequest dto,
             @AuthenticationPrincipal CustomUserDetails user) {
-        String memberId = (user != null) ? user.userId() : null;
-        commentCommandService.createChildComment(parentCommentId, dto.content(), memberId);
+        commentCommandService.createChildComment(parentCommentId, dto.content(), user.userId());
         return ResponseEntity.ok(ApiResponse.success());
     }
 
@@ -83,8 +81,7 @@ public class CommentController {
     public ResponseEntity<ApiResponse<Void>> deleteComment(
             @PathVariable(name = "commentId") String commentId,
             @AuthenticationPrincipal CustomUserDetails user) {
-        String memberId = (user != null) ? user.userId() : null;
-        commentCommandService.deleteComment(commentId, memberId);
+        commentCommandService.deleteComment(commentId, user.userId());
         return ResponseEntity.ok(ApiResponse.success());
     }
 

--- a/src/main/java/com/algangi/mongle/map/application/service/MapQueryService.java
+++ b/src/main/java/com/algangi/mongle/map/application/service/MapQueryService.java
@@ -37,7 +37,7 @@ public class MapQueryService {
     private final S2PolygonConverter s2PolygonConverter;
     private final BlockQueryService blockQueryService;
 
-    public MapObjectsResponse getMapObjects(MapObjectsRequest request) {
+    public MapObjectsResponse getMapObjects(MapObjectsRequest request, String memberId) {
         List<String> s2cellTokens = s2CellService.getCellsForRect(
             request.swLat(), request.swLng(), request.neLat(), request.neLng()
         );
@@ -46,7 +46,7 @@ public class MapQueryService {
             return MapObjectsResponse.empty();
         }
 
-        List<String> blockedAuthorIds = blockQueryService.getBlockedUserIds(request.memberId());
+        List<String> blockedAuthorIds = blockQueryService.getBlockedUserIds(memberId);
 
         List<Post> grains = postQueryRepository.findGrainsInCells(s2cellTokens, blockedAuthorIds);
 

--- a/src/main/java/com/algangi/mongle/map/presentation/controller/MapController.java
+++ b/src/main/java/com/algangi/mongle/map/presentation/controller/MapController.java
@@ -1,5 +1,6 @@
 package com.algangi.mongle.map.presentation.controller;
 
+import com.algangi.mongle.auth.infrastructure.security.authentication.CustomUserDetails;
 import com.algangi.mongle.global.dto.ApiResponse;
 import com.algangi.mongle.map.application.service.MapQueryService;
 import com.algangi.mongle.map.presentation.dto.MapObjectsRequest;
@@ -7,6 +8,7 @@ import com.algangi.mongle.map.presentation.dto.MapObjectsResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -21,9 +23,9 @@ public class MapController {
 
     @GetMapping("/objects")
     public ResponseEntity<ApiResponse<MapObjectsResponse>> getMapObjects(
-        @Valid @ModelAttribute MapObjectsRequest request) {
-
-        MapObjectsResponse response = mapQueryService.getMapObjects(request);
+            @Valid @ModelAttribute MapObjectsRequest request,
+            @AuthenticationPrincipal CustomUserDetails user) {
+        MapObjectsResponse response = mapQueryService.getMapObjects(request, user.userId());
         return ResponseEntity.ok(ApiResponse.success(response));
     }
 }

--- a/src/main/java/com/algangi/mongle/map/presentation/dto/MapObjectsRequest.java
+++ b/src/main/java/com/algangi/mongle/map/presentation/dto/MapObjectsRequest.java
@@ -6,8 +6,7 @@ public record MapObjectsRequest(
     @NotNull(message = "swLat은 필수값입니다.") Double swLat,
     @NotNull(message = "swLng은 필수값입니다.") Double swLng,
     @NotNull(message = "neLat은 필수값입니다.") Double neLat,
-    @NotNull(message = "neLng은 필수값입니다.") Double neLng,
-    String memberId
+    @NotNull(message = "neLng은 필수값입니다.") Double neLng
 ) {
 
 }

--- a/src/main/java/com/algangi/mongle/post/application/service/PostQueryService.java
+++ b/src/main/java/com/algangi/mongle/post/application/service/PostQueryService.java
@@ -61,7 +61,7 @@ public class PostQueryService {
     public PostListResponse getPostList(PostListRequest request, String currentMemberId) {
         validateCloudExists(request);
 
-        List<String> blockedAuthorIds = blockQueryService.getBlockedUserIds(request.memberId());
+        List<String> blockedAuthorIds = blockQueryService.getBlockedUserIds(currentMemberId);
 
         List<Post> fetchedPosts = postQueryRepository.findPostsByCondition(request,
             blockedAuthorIds);

--- a/src/main/java/com/algangi/mongle/post/presentation/dto/PostListRequest.java
+++ b/src/main/java/com/algangi/mongle/post/presentation/dto/PostListRequest.java
@@ -7,8 +7,7 @@ public record PostListRequest(
     String cloudId,
     String cursor,
     Integer size,
-    PostSort sortBy,
-    String memberId
+    PostSort sortBy
 ) {
 
     private static final int DEFAULT_SIZE = 10;

--- a/src/main/java/com/algangi/mongle/reaction/presentation/controller/ReactionController.java
+++ b/src/main/java/com/algangi/mongle/reaction/presentation/controller/ReactionController.java
@@ -1,11 +1,13 @@
 package com.algangi.mongle.reaction.presentation.controller;
 
+import com.algangi.mongle.auth.infrastructure.security.authentication.CustomUserDetails;
 import com.algangi.mongle.global.dto.ApiResponse;
 import com.algangi.mongle.reaction.application.service.ReactionApplicationService;
 import com.algangi.mongle.reaction.presentation.dto.ReactionRequest;
 import com.algangi.mongle.reaction.presentation.dto.ReactionResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -20,12 +22,12 @@ public class ReactionController {
             @PathVariable String targetType,
             @PathVariable String targetId,
             @RequestBody ReactionRequest request,
-            @RequestParam String memberId
+            @AuthenticationPrincipal CustomUserDetails user
     ) {
         ReactionResponse result = reactionApplicationService.updateReaction(
                 targetType,
                 targetId,
-                memberId,
+                user.userId(),
                 request.reactionType()
         );
 


### PR DESCRIPTION
## 📄Summary
- memberId 쿼리 파라미터에 인증 사용자 기반으로 변경


<br><br>

## 🔗관련 이슈
- Close #98 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신규 기능
  - 차단/차단해제/차단 목록, 댓글 작성·삭제, 반응 업데이트, 지도 객체 조회, 게시글 목록이 로그인한 내 계정 기준으로 자동 적용됩니다.
  - 내 차단 목록이 지도/게시글 노출에 일관되게 반영됩니다.

- 리팩터링
  - API 호출 시 memberId 전달이 필요 없습니다. 인증된 사용자 정보가 자동 사용됩니다.
  - 지도 조회 및 게시글 목록 요청에서 memberId 필드가 제거되어 클라이언트 호출이 간소화되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->